### PR TITLE
fix rpc lib

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -47,7 +47,7 @@
 		"lint": "tslint '*/*.{ts,tsx}' -c ./tslint.yml"
 	},
 	"dependencies": {
-		"@sap-devx/webview-rpc": "^0.1.3",
+		"@sap-devx/webview-rpc": "^0.2.0",
 		"datauri": "^2.0.0",
 		"lodash": "^4.17.15",
 		"strip-ansi": "^6.0.0",


### PR DESCRIPTION
this will fix the problem that a typo fix in the rpc-lib API without minor version release, caused breaking the websocket server.
Issue: [https://github.com/SAP/yeoman-ui/issues/58](https://github.com/SAP/yeoman-ui/issues/58)