### PR TITLE
Support package path from yeoman-environment 2.8.1

### DIFF
--- a/backend/src/yeomanui.ts
+++ b/backend/src/yeomanui.ts
@@ -145,7 +145,8 @@ export class YeomanUI {
       const env: Environment = Environment.createEnv(undefined, {}, this.youiAdapter);
       const meta: Environment.GeneratorMeta = this.getGenMetadata(generatorName);
       // TODO: support sub-generators
-      env.register(meta.resolved);
+      // @ts-ignore
+      env.register(meta.resolved, meta.namespace, meta.packagePath);
 
       const genNamespace = this.getGenNamespace(generatorName);
       const gen: any = env.create(genNamespace, {options: {logger: this.logger.getChildLogger({label: generatorName})}});


### PR DESCRIPTION
Aligns behaviour of CLI and Yeoman-UI with-regard-to supported package naming. i.e Yeoman environment 2.8.1 allows generator package paths to be registered so the default is not used. For example, where the package path cannot be re-named to match generator-*.

Since @types/yeoman-environment is somewhat behind (2.3.3), I have had to add @ts-ignore for expedience.