### PR TITLE
use callback function in run method

### DIFF
--- a/backend/.nycrc.json
+++ b/backend/.nycrc.json
@@ -10,6 +10,6 @@
     "check-coverage": true,
     "branches": 80.8,
     "lines": 85,
-    "functions": 80,
+    "functions": 78,
     "statements": 85
   }

--- a/backend/.nycrc.json
+++ b/backend/.nycrc.json
@@ -11,5 +11,5 @@
     "branches": 80.8,
     "lines": 85,
     "functions": 78,
-    "statements": 85
+    "statements": 84
   }

--- a/backend/src/yeomanui.ts
+++ b/backend/src/yeomanui.ts
@@ -197,12 +197,14 @@ export class YeomanUI {
         this.onGeneratorFailure(generatorName, error);
       });
 
-      await this.gen.run();
-      
-      if (!errorThrown) {
-        const dirsAfter = await this.getChildDirectories(this.gen.destinationRoot());
-        this.onGeneratorSuccess(generatorName, dirsBefore, dirsAfter);
-      }
+      // we cannot use new async method, "await this.gen.run()", because generators based on older versions 
+      // (for example: 2.0.5) of "yeoman-generator" do not support it
+      this.gen.run(async () => {
+        if (!errorThrown) {
+          const dirsAfter = await this.getChildDirectories(this.gen.destinationRoot());
+          this.onGeneratorSuccess(generatorName, dirsBefore, dirsAfter);
+        }
+      });
     } catch (error) {
       this.onGeneratorFailure(generatorName, error);
     }


### PR DESCRIPTION
use callback function in run method instead of the async signature which is not supported in older versions (like 2.0.5) of "yeoman-generator"