### PR TITLE
Show "Add to Workspace" button in the "The project has been generated" message only when no one of the the workspace folders is predecessor of the project folder.

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "yeoman-ui",
-	"version": "1.1.23",
+	"version": "1.1.24",
 	"displayName": "Application Wizard",
 	"publisher": "SAPOS",
 	"author": {

--- a/backend/src/vscode-youi-events.ts
+++ b/backend/src/vscode-youi-events.ts
@@ -3,6 +3,7 @@ import * as _ from 'lodash';
 import { YouiEvents } from "./youi-events";
 import { IRpc } from "@sap-devx/webview-rpc/out.ext/rpc-common";
 import { GeneratorFilter, GeneratorType } from './filter';
+import { relative, isAbsolute } from 'path';
 
 export class VSCodeYouiEvents implements YouiEvents {
     private webviewPanel: vscode.WebviewPanel;
@@ -51,6 +52,27 @@ export class VSCodeYouiEvents implements YouiEvents {
         }
     }
 
+    /**
+     * Returns true in case probablePredecessorPath is the predecessor path of currentPath.
+     * In other words, returns true when currentPath is contained in some place in probablePredecessorPath.
+     * It can not be implemented by currentPath.contains(probablePredecessorPath), because the path can be the following for example (see tests):
+     * /home/user/projects/../projects
+     * /home/user/./projects
+     * And te pathes above are valid.
+     * So we need to use relative() of path.
+     * When relative path starts with '..', it means that the the pathes don't have a common part.
+     * Otherwise, the pathes have a common part and probablePredecessorPath is really predecessor of currentPath.
+     * The check isAbsolute() is needed for the following case (see it("on success, project path and workspace folder are Windows style ---> add to workspace button and open in new workspace button are visible"):
+     * probablePredecessorPath = "C:\\Windows" and currentPath = "D:\\Program Files".
+     * 
+     * @param probablePredecessorPath 
+     * @param currentPath 
+     */
+    private isPredecessorOf(probablePredecessorPath: string, currentPath: string) {
+        const relativePath = relative(probablePredecessorPath, currentPath);
+        return relativePath && !_.startsWith(relativePath, '..') && !isAbsolute(relativePath);
+    }
+
     private showDoneMessage(success: boolean, errorMmessage: string, targetFolderPath?: string): Thenable<any> {
         this.resolveInstallingProgress();
 
@@ -65,7 +87,8 @@ export class VSCodeYouiEvents implements YouiEvents {
                 const workspacePath = _.get(vscode, "workspace.workspaceFolders[0].uri.fsPath");
                 // 1. target workspace folder should not already contain target generator folder
                 const foundInWorkspace = _.find(vscode.workspace.workspaceFolders, (wsFolder: vscode.WorkspaceFolder) => {
-                    return targetFolderUri.fsPath === wsFolder.uri.fsPath;
+                    // wsFolder is accessor of targetFolderUri, so targetFolderUri is already shown inside wsFolder
+                    return ((wsFolder.uri.fsPath === targetFolderUri.fsPath) || this.isPredecessorOf(wsFolder.uri.fsPath, targetFolderUri.fsPath));
                 });
                 // 2. Theia bug: vscode.workspace.workspaceFolders should not be undefined or empty
                 if (!foundInWorkspace && workspacePath) {

--- a/backend/tests/vscode-youi-events.spec.ts
+++ b/backend/tests/vscode-youi-events.spec.ts
@@ -69,7 +69,17 @@ describe('vscode-youi-events unit test', () => {
             return events.doGeneratorDone(true, "success message", "testDestinationRoot");
         });
 
-        it("on success, open in new workspace button is visible", () => {
+        it("on success, project path and workspace folder are Windows style ---> add to workspace button and open in new workspace button are visible", () => {
+            eventsMock.expects("doClose");
+            const actionName1 = 'Add to Workspace';
+            const actionName2 = 'Open in New Workspace';
+            _.set(vscode, "workspace.workspaceFolders", [{uri: {fsPath: "C:\\Windows"}}]);
+            windowMock.expects("showInformationMessage").
+                withExactArgs(`${messages.default.artifact_generated}\nWhat would you like to do with it?`, actionName1, actionName2).resolves();
+            return events.doGeneratorDone(true, "success message", "D:\\Program Files");
+        });
+
+        it("on success, project path is already openned in workspace ---> only open in new workspace button is visible", () => {
             eventsMock.expects("doClose");
             _.set(vscode, "workspace.workspaceFolders", [{uri: {fsPath: "rootFolderPath"}}, {uri: {fsPath: "testDestinationRoot"}}]);
             const actionName = 'Open in New Workspace';
@@ -77,6 +87,56 @@ describe('vscode-youi-events unit test', () => {
                 withExactArgs(`${messages.default.artifact_generated}\nWhat would you like to do with it?`, actionName).resolves(actionName);
             commandsMock.expects("executeCommand").withArgs("vscode.openFolder").resolves();
             return events.doGeneratorDone(true, "success message", "testDestinationRoot");
+        });
+
+        it("on success, project path parent folder is already openned in workspace ---> only open in new workspace button is visible", () => {
+            eventsMock.expects("doClose");
+            _.set(vscode, "workspace.workspaceFolders", [{uri: {fsPath: "rootFolderPath"}}, {uri: {fsPath: "testDestinationRoot"}}]);
+            const actionName = 'Open in New Workspace';
+            windowMock.expects("showInformationMessage").
+                withExactArgs(`${messages.default.artifact_generated}\nWhat would you like to do with it?`, actionName).resolves(actionName);
+            commandsMock.expects("executeCommand").withArgs("vscode.openFolder").resolves();
+            return events.doGeneratorDone(true, "success message", "testDestinationRoot/projectName");
+        });
+
+        it("on success, project path parent folder is already openned in workspace, path with '.' ---> only open in new workspace button is visible", () => {
+            eventsMock.expects("doClose");
+            _.set(vscode, "workspace.workspaceFolders", [{uri: {fsPath: "rootFolderPath"}}, {uri: {fsPath: "testDestinationRoot"}}]);
+            const actionName = 'Open in New Workspace';
+            windowMock.expects("showInformationMessage").
+                withExactArgs(`${messages.default.artifact_generated}\nWhat would you like to do with it?`, actionName).resolves(actionName);
+            commandsMock.expects("executeCommand").withArgs("vscode.openFolder").resolves();
+            return events.doGeneratorDone(true, "success message", "testDestinationRoot/./projectName");
+        });
+
+        it("on success, project path parent folder is already openned in workspace, path with '..' ---> only open in new workspace button is visible", () => {
+            eventsMock.expects("doClose");
+            _.set(vscode, "workspace.workspaceFolders", [{uri: {fsPath: "rootFolderPath"}}, {uri: {fsPath: "testDestinationRoot"}}]);
+            const actionName = 'Open in New Workspace';
+            windowMock.expects("showInformationMessage").
+                withExactArgs(`${messages.default.artifact_generated}\nWhat would you like to do with it?`, actionName).resolves(actionName);
+            commandsMock.expects("executeCommand").withArgs("vscode.openFolder").resolves();
+            return events.doGeneratorDone(true, "success message", "testDestinationRoot/projectName/../projectName");
+        });
+
+        it("on success, project path parent folder is already openned in workspace, workspaceFolders with '..' ---> only open in new workspace button is visible", () => {
+            eventsMock.expects("doClose");
+            _.set(vscode, "workspace.workspaceFolders", [{uri: {fsPath: "rootFolderPath"}}, {uri: {fsPath: "testDestinationRoot/../testDestinationRoot"}}]);
+            const actionName = 'Open in New Workspace';
+            windowMock.expects("showInformationMessage").
+                withExactArgs(`${messages.default.artifact_generated}\nWhat would you like to do with it?`, actionName).resolves(actionName);
+            commandsMock.expects("executeCommand").withArgs("vscode.openFolder").resolves();
+            return events.doGeneratorDone(true, "success message", "testDestinationRoot/projectName/../projectName");
+        });
+
+        it("on success, project path grand parent folder is already openned in workspace ---> only open in new workspace button is visible", () => {
+            eventsMock.expects("doClose");
+            _.set(vscode, "workspace.workspaceFolders", [{uri: {fsPath: "rootFolderPath"}}, {uri: {fsPath: "testDestinationRoot"}}]);
+            const actionName = 'Open in New Workspace';
+            windowMock.expects("showInformationMessage").
+                withExactArgs(`${messages.default.artifact_generated}\nWhat would you like to do with it?`, actionName).resolves(actionName);
+            commandsMock.expects("executeCommand").withArgs("vscode.openFolder").resolves();
+            return events.doGeneratorDone(true, "success message", "testDestinationRoot/projectName/moduleName");
         });
 
         it("on success, add to workspace button is pressed", () => {
@@ -93,8 +153,6 @@ describe('vscode-youi-events unit test', () => {
         it("on success, no buttons are displayed", () => {
             eventsMock.expects("doClose");
             _.set(vscode, "workspace.workspaceFolders", [{uri: {fsPath: "testDestinationRoot"}}]);
-            const actionName1 = 'Add to Workspace';
-            const actionName2 = 'Open in New Workspace';
             windowMock.expects("showInformationMessage").
                 withExactArgs(messages.default.artifact_generated).resolves();
             return events.doGeneratorDone(true, "success message", "testDestinationRoot");


### PR DESCRIPTION
Show "Add to Workspace" button in the "The project has been generated" message only when no one of the the workspace folders is predecessor of the project folder.