### PR TITLE
When 'Open in new workspace' and 'Add to workspace' should be shown.

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "yeoman-ui",
-	"version": "1.1.28",
+	"version": "1.1.29",
 	"displayName": "Application Wizard",
 	"publisher": "SAPOS",
 	"author": {

--- a/backend/src/vscode-youi-events.ts
+++ b/backend/src/vscode-youi-events.ts
@@ -114,10 +114,14 @@ export class VSCodeYouiEvents implements YouiEvents {
             const addToWorkspace = "Add to Workspace";
             const openInNewWorkspace: any = "Open in New Workspace";
             const items: string[] = [];
-            
-            const targetFolderUri: vscode.Uri = vscode.Uri.file(targetFolderPath);
+            let targetFolderUri: vscode.Uri = null;
 
-            if (!_.includes(this.genFilter.types, GeneratorType.module)) {
+            // The correct targetFolderPath is unknown ---> no buttons should be shown
+            if (!_.isNil(targetFolderPath)) {
+                // Target folder is visible in workpace ---> addToWorkspace only
+                // Target folder is not visible in workpace ---> addToWorkspace and openInNewWorkspace
+
+                targetFolderUri = vscode.Uri.file(targetFolderPath);
                 const workspacePath = _.get(vscode, "workspace.workspaceFolders[0].uri.fsPath");
                 // 1. target workspace folder should not already contain target generator folder
                 const foundInWorkspace = _.find(vscode.workspace.workspaceFolders, (wsFolder: vscode.WorkspaceFolder) => {

--- a/backend/tests/vscode-youi-events.spec.ts
+++ b/backend/tests/vscode-youi-events.spec.ts
@@ -206,7 +206,7 @@ describe('vscode-youi-events unit test', () => {
             return events.doGeneratorDone(true, "success message", "testDestinationRoot");
         });
 
-        it("on success, no buttons are displayed", () => {
+        it("on success with the project already opened in the workspace, no buttons are displayed", () => {
             eventsMock.expects("doClose");
             _.set(vscode, "workspace.workspaceFolders", [{uri: {fsPath: "testDestinationRoot"}}]);
             windowMock.expects("showInformationMessage").
@@ -214,20 +214,18 @@ describe('vscode-youi-events unit test', () => {
             return events.doGeneratorDone(true, "success message", "testDestinationRoot");
         });
 
+        it("on success with null targetFolderPath, no buttons are displayed", () => {
+            eventsMock.expects("doClose");
+            _.set(vscode, "workspace.workspaceFolders", [{uri: {fsPath: "rootFolderPath"}}]);
+            windowMock.expects("showInformationMessage").
+                withExactArgs(messages.default.artifact_generated).resolves();
+            return events.doGeneratorDone(true, "success message", null);
+        });
+
         it("on failure", () => {
             eventsMock.expects("doClose");
             windowMock.expects("showErrorMessage").withExactArgs("error message");
             return events.doGeneratorDone(false, "error message");
-        });
-
-        it("generator filter type is module", () => {
-            const genFilter = GeneratorFilter.create({type: ["module"]});
-            loggerWrapperMock.expects("getClassLogger");
-            const testEvents = new VSCodeYouiEvents(undefined, undefined, genFilter, messages.default, undefined);
-            eventsMock = sandbox.mock(testEvents);
-            eventsMock.expects("doClose");
-            windowMock.expects("showInformationMessage").withExactArgs(messages.default.artifact_generated).resolves();
-            return testEvents.doGeneratorDone(true, "success message", "testDestinationRoot");
         });
     });
 });

--- a/backend/tests/yeomanui.spec.ts
+++ b/backend/tests/yeomanui.spec.ts
@@ -669,7 +669,7 @@ describe('yeomanui unit test', () => {
         it("onGeneratorSuccess - one dir was created", () => {
             const beforeGen = {targetFolderPath: "testDestinationRoot", childDirs: ["dirparh1"]};
             const afterGen = {targetFolderPath: "testDestinationRoot", childDirs: ["dirparh1", "dirpath2"]};
-            swaTrackerWrapperMock.expects("updateGeneratorEnded").withArgs("testGenerator", true);
+            swaTrackerWrapperMock.expects("updateGeneratorEnded").withArgs("testGenName", true, testLogger);
             yeomanUi["onGeneratorSuccess"]("testGenName", beforeGen, afterGen);
             expect(doGeneratorDoneSpy.calledWith(true, _.get(yeomanUi, "uiOptions.messages.artifact_with_name_generated")("testGenName"), "dirpath2")).to.be.true;
         });
@@ -677,13 +677,29 @@ describe('yeomanui unit test', () => {
         it("onGeneratorSuccess - two dirs were created", () => {
             const beforeGen = {targetFolderPath: "testDestinationRoot", childDirs: ["dirparh1"]};
             const afterGen = {targetFolderPath: "testDestinationRoot", childDirs: ["dirparh1", "dirpath2", "dirpath3"]};
-            swaTrackerWrapperMock.expects("updateGeneratorEnded").withArgs("testGenerator", true);
+            swaTrackerWrapperMock.expects("updateGeneratorEnded").withArgs("testGenName", true, testLogger);
             yeomanUi["onGeneratorSuccess"]("testGenName", beforeGen, afterGen);
-            expect(doGeneratorDoneSpy.calledWith(true, _.get(yeomanUi, "uiOptions.messages.artifact_with_name_generated")("testGenName"), "testDestinationRoot")).to.be.true;
+            expect(doGeneratorDoneSpy.calledWith(true, _.get(yeomanUi, "uiOptions.messages.artifact_with_name_generated")("testGenName"), null)).to.be.true;
+        });
+
+        it("onGeneratorSuccess - zero dirs were created", () => {
+            const beforeGen = {targetFolderPath: "testDestinationRoot", childDirs: ["dirparh1"]};
+            const afterGen = {targetFolderPath: "testDestinationRoot", childDirs: ["dirparh1"]};
+            swaTrackerWrapperMock.expects("updateGeneratorEnded").withArgs("testGenName", true, testLogger);
+            yeomanUi["onGeneratorSuccess"]("testGenName", beforeGen, afterGen);
+            expect(doGeneratorDoneSpy.calledWith(true, _.get(yeomanUi, "uiOptions.messages.artifact_with_name_generated")("testGenName"), null)).to.be.true;
+        });
+
+        it("onGeneratorSuccess - targetFolderPath was changed by generator", () => {
+            const beforeGen = {targetFolderPath: "testDestinationRoot"};
+            const afterGen = {targetFolderPath: "testDestinationRoot/generatedProject"};
+            swaTrackerWrapperMock.expects("updateGeneratorEnded").withArgs("testGenName", true, testLogger);
+            yeomanUi["onGeneratorSuccess"]("testGenName", beforeGen, afterGen);
+            expect(doGeneratorDoneSpy.calledWith(true, _.get(yeomanUi, "uiOptions.messages.artifact_with_name_generated")("testGenName"), "testDestinationRoot/generatedProject")).to.be.true;
         });
 
         it("onGeneratorFailure", async () => {
-            swaTrackerWrapperMock.expects("updateGeneratorEnded").withArgs("testGenerator", false);
+            swaTrackerWrapperMock.expects("updateGeneratorEnded").withArgs("testGenName", false, testLogger);
             await yeomanUi["onGeneratorFailure"]("testGenName", "testError");
             expect(doGeneratorDoneSpy.calledWith(false, `{"message":"testGenName generator failed - testError"}`)).to.be.true;
         });


### PR DESCRIPTION
Tested in BAS and in VS Code.

Fixes several bugs. 
DEVXCORE-2144
Created additional BI DEVXCORE-2158 with the following bugs:
Scenario 1:
File -> New Project From Template
Specify a target folder path: /home/user/ (remove projects manually).
Choose MTA -> name it mta -> complete and choose "Add project to workspace".
Result: user folder added to workspace.
Expected result: user/mta folder added to workspace.
Works correctly if target folder path: /home/user (without slash at the end).
Fix: use resolve to remove / as well.

Scenario 2:
File -> New Project From Template
Specify a target folder path: lib (fill manually).
Choose MTA -> name it mta -> complete.
Result: project generation fails with the following message:
{"message":"basic-multitarget-application generator failed - mkdir /theia: permission denied","stack":"Error: mkdir /theia: permission denied\n at ChildProcess.<anonymous> (/extbin/generators/lib/node_modules/generator-basic-multitarget-application/node_modules/@sap/mta-lib/lib/index.js:60:20)\n at ChildProcess.emit (events.js:315:20)\n at Process.ChildProcess._handle.onexit (internal/child_process.js:275:12)"}
Root cause: in case of relative path the code use theia current directory (/theia/browser-app/).
The same happens on Windows because it tries to create in C:\Program Files\Microsoft VS Code folder.
Fix: use resolve(outputPath, ...) to create an absolute path based on outputPath.