### PR TITLE
Fix bug in generator foodQ.

### DIFF
--- a/generator-foodq/generators/app/index.js
+++ b/generator-foodq/generators/app/index.js
@@ -348,7 +348,9 @@ module.exports = class extends Generator {
   }
 
   writing() {
-    this.log.showProgress("FoodQ is generating.");
+    if (_.get(this.log, "showProgress")) {
+        this.log.showProgress("FoodQ is generating.");
+    }
     this.log('in writing');
     this.fs.copyTpl(this.templatePath('index.html'),
       this.destinationPath('public/index.html'), {


### PR DESCRIPTION
log.showProgress should be called when exists only. It does not exist in the yeoman cli.