### PR TITLE
fix: launching with 'generator:' property - clear the 'replay' cache

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "yeoman-ui",
-	"version": "1.1.59",
+	"version": "1.1.60",
 	"displayName": "Application Wizard",
 	"publisher": "SAPOS",
 	"author": {

--- a/backend/src/yeomanui.ts
+++ b/backend/src/yeomanui.ts
@@ -326,8 +326,8 @@ export class YeomanUI {
 				await this._notifyGeneratorsInstall(this.uiOptions.installGens, true);
 				const response: any = await this.rpc.invoke("showPrompt", [generators.questions, "select_generator"]);
 				generatorId = response.generator;
+				this.replayUtils.clear();
 			}
-			this.replayUtils.clear();
 			SWA.updateGeneratorStarted(generatorId, this.logger);
 			if (!_.includes(generatorId, ":")) {
 				generatorId = this.getGenNamespace(generatorId);


### PR DESCRIPTION
When executeCommand("loadYeomanUI") with 'generator:' property - then clicking back to 1st generator prompt, it resets the 'replay' cache.