### PR TITLE
feat: open yeoman ui in split mode

### DIFF
--- a/packages/backend/src/panels/AbstractWebviewPanel.ts
+++ b/packages/backend/src/panels/AbstractWebviewPanel.ts
@@ -23,10 +23,13 @@ export abstract class AbstractWebviewPanel {
   protected isInBAS: boolean;
   protected rpc: RpcExtension;
   protected flowPromise: FlowPromise<void>;
+  protected viewColumn: vscode.ViewColumn;
 
-  public loadWebviewPanel(uiOptions?: unknown): Promise<void> {
+  public loadWebviewPanel(uiOptions?: any): Promise<void> {
     this.disposeWebviewPanel();
-
+    if (uiOptions?.viewColumn in vscode.ViewColumn) {
+      this.viewColumn = uiOptions.viewColumn;
+    }
     const webViewPanel = this.createWebviewPanel();
     this.setWebviewPanel(webViewPanel, uiOptions);
 
@@ -41,6 +44,7 @@ export abstract class AbstractWebviewPanel {
     this.disposables = [];
     this.context = context;
     this.isInBAS = !_.isEmpty(_.get(process, "env.WS_BASE_URL"));
+    this.viewColumn = vscode.ViewColumn.One;
   }
 
   public setWebviewPanel(webviewPanel: vscode.WebviewPanel, state?: unknown) {
@@ -50,7 +54,7 @@ export abstract class AbstractWebviewPanel {
   }
 
   public createWebviewPanel(): vscode.WebviewPanel {
-    return vscode.window.createWebviewPanel(this.viewType, this.viewTitle, vscode.ViewColumn.One, {
+    return vscode.window.createWebviewPanel(this.viewType, this.viewTitle, this.viewColumn, {
       // Enable javascript in the webview
       enableScripts: true,
       retainContextWhenHidden: true,

--- a/packages/backend/src/utils/vscodeProxy.ts
+++ b/packages/backend/src/utils/vscodeProxy.ts
@@ -70,6 +70,7 @@ const window = {
 
 const ViewColumn = {
   One: 1,
+  Two: 2,
 };
 
 const vscodeMock = {

--- a/packages/backend/test/panels/YeomanUIPanel.spec.ts
+++ b/packages/backend/test/panels/YeomanUIPanel.spec.ts
@@ -78,6 +78,12 @@ describe("YeomanUIPanel unit test", () => {
         void panel.loadWebviewPanel({ generator: "test:app" });
       });
 
+      it("existing generator is provided with viewColumn parameter, in VSCODE", () => {
+        envUtilsMock.expects("getAllGeneratorNamespaces").resolves(["gen1:test", "test:app", "code:app"]);
+        npmUtilsMock.expects("checkAccessAndSetGeneratorsPath").never();
+        void panel.loadWebviewPanel({ generator: "test:app", viewColumn: vscode.ViewColumn.Two });
+      });
+
       it("provided generator does not exist, in VSCODE", () => {
         envUtilsMock.expects("getAllGeneratorNamespaces").resolves(["gen1:test", "code:app"]);
         npmUtilsMock.expects("checkAccessAndSetGeneratorsPath").resolves();
@@ -105,6 +111,12 @@ describe("YeomanUIPanel unit test", () => {
         envUtilsMock.expects("getAllGeneratorNamespaces").resolves(["gen1:test", "test:app", "code:app"]);
         npmUtilsMock.expects("checkAccessAndSetGeneratorsPath").never();
         void panel.loadWebviewPanel({ generator: "test:app" });
+      });
+
+      it("existing generator is provided with viewColumn parameter, in VSCODE", () => {
+        envUtilsMock.expects("getAllGeneratorNamespaces").resolves(["gen1:test", "test:app", "code:app"]);
+        npmUtilsMock.expects("checkAccessAndSetGeneratorsPath").never();
+        void panel.loadWebviewPanel({ generator: "test:app", viewColumn: vscode.ViewColumn.Two });
       });
 
       it("provided generator does not exist", () => {


### PR DESCRIPTION
in some scenarios, it is desired to open yeoman-ui webview in split mode so that user does not have
to switch between tabs