### PR TITLE
Add styling for for separator in dropdown lists

### DIFF
--- a/packages/frontend/src/assets/css/globalStyles.css
+++ b/packages/frontend/src/assets/css/globalStyles.css
@@ -71,6 +71,14 @@ div.v-select-list div.v-list div.v-list-item:not(.v-list-item--active):not(.v-li
   color: var(--vscode-dropdown-foreground);
 }
 
+/* Styling for separator in <v-select> component */
+div.v-select-list  > div.v-list-item--disabled > .v-subheader{
+  text-transform: uppercase;
+  font-weight: 800;
+  font-size: 11px;
+  color: var(--vscode-foreground, #cccccc);
+}
+
 .v-textarea.v-input:not(.v-input--is-disabled) input{
   color: var(--vscode-input-foreground, #cccccc);
 }


### PR DESCRIPTION
Fix CSS styling for users who want to use a separator in the dropdown list.
Before:
![Screenshot 2022-05-09 at 15 56 44](https://user-images.githubusercontent.com/2386570/167437808-d9804996-58ee-4993-8ff1-432e48e16d91.png)

After:
![Screenshot 2022-05-09 at 15 42 39](https://user-images.githubusercontent.com/2386570/167436871-693dc970-887b-433a-b039-22f092a31380.png)

