### PR TITLE
feat(App.vue): Adds support for command execution with object parameters

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@mdi/font": "5.9.55",
-    "@sap-devx/inquirer-gui": "0.2.1",
+    "@sap-devx/inquirer-gui": "0.3.0",
     "@sap-devx/inquirer-gui-file-browser-plugin": "0.0.5",
     "@sap-devx/inquirer-gui-folder-browser-plugin": "0.0.3",
     "@sap-devx/inquirer-gui-label-plugin": "0.0.1",

--- a/packages/frontend/src/youi/App.vue
+++ b/packages/frontend/src/youi/App.vue
@@ -266,10 +266,13 @@ export default {
         this.showBusyIndicator = false;
       }
     },
-    executeCommand(event) {
-      const command = event.target.getAttribute("command");
-      const params = event.target.getAttribute("params");
-      this.rpc.invoke("executeCommand", [command, params]);
+    executeCommand(cmdOrEvent) {
+      let command = cmdOrEvent;
+      if (cmdOrEvent.target) {
+        command.id = cmdOrEvent.target.getAttribute("command");
+        command.params = cmdOrEvent.target.getAttribute("params");
+      }
+      this.rpc.invoke("executeCommand", [command.id, command.params]);
     },
     back() {
       return this.gotoStep(1); // go 1 step back

--- a/packages/frontend/test/App.spec.js
+++ b/packages/frontend/test/App.spec.js
@@ -504,7 +504,7 @@ describe("App.vue", () => {
     expect(wrapper.vm.logText).toBe("test_test_log");
   });
 
-  it("executeCommand - method", () => {
+  it("executeCommand:event - method", () => {
     wrapper = initComponent(App, {}, true);
     wrapper.vm.rpc = {
       invoke: jest.fn(),
@@ -521,6 +521,32 @@ describe("App.vue", () => {
     wrapper.vm.executeCommand(event);
 
     expect(invokeSpy).toHaveBeenCalledWith("executeCommand", ["vscode.open", ["param"]]);
+
+    invokeSpy.mockRestore();
+  });
+
+  it("executeCommand:command - method", () => {
+    wrapper = initComponent(App, {}, true);
+    wrapper.vm.rpc = {
+      invoke: jest.fn(),
+    };
+
+    /**
+     * @see {IValidationLink.link.command}
+     */
+    const command = {
+      id: "vscode.open",
+      params: {
+        a: {
+          b: 1
+        },
+        c: ["2", "3"]
+      }
+    };
+    const invokeSpy = jest.spyOn(wrapper.vm.rpc, "invoke");
+    wrapper.vm.executeCommand(command);
+
+    expect(invokeSpy).toHaveBeenCalledWith("executeCommand", ["vscode.open", command.params]);
 
     invokeSpy.mockRestore();
   });

--- a/packages/frontend/test/App.spec.js
+++ b/packages/frontend/test/App.spec.js
@@ -538,10 +538,10 @@ describe("App.vue", () => {
       id: "vscode.open",
       params: {
         a: {
-          b: 1
+          b: 1,
         },
-        c: ["2", "3"]
-      }
+        c: ["2", "3"],
+      },
     };
     const invokeSpy = jest.spyOn(wrapper.vm.rpc, "invoke");
     wrapper.vm.executeCommand(command);

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -63,31 +63,31 @@ export interface IPrompt {
 /**
  * Enhanced validation messages to support embedded help urls and commands
  */
- export interface IValidationLink {
+export interface IValidationLink {
   /**
    * Validation message to be shown to the end user
    */
   message: string;
   link: {
-      /**
-       * The text associated with the help link
-       */
-      text: string;
-      /**
-       * A string base64 encoded image
-       */
-      icon?: string;
-      /**
-       * Command to be exectuted and parameters passed to the command
-       */
-      command?: {
-          id: string;
-          params: Object | string;
-      };
-      /**
-       * A http url string
-       */
-      url?: string;
+    /**
+     * The text associated with the help link
+     */
+    text: string;
+    /**
+     * A string base64 encoded image
+     */
+    icon?: string;
+    /**
+     * Command to be exectuted and parameters passed to the command
+     */
+    command?: {
+      id: string;
+      params: Object | string;
+    };
+    /**
+     * A http url string
+     */
+    url?: string;
   };
   /**
    * Provide a stringified version of the link that will be used on the CLI

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -59,3 +59,38 @@ export interface IPrompt {
   name: string;
   description: string;
 }
+
+/**
+ * Enhanced validation messages to support embedded help urls and commands
+ */
+ export interface IValidationLink {
+  /**
+   * Validation message to be shown to the end user
+   */
+  message: string;
+  link: {
+      /**
+       * The text associated with the help link
+       */
+      text: string;
+      /**
+       * A string base64 encoded image
+       */
+      icon?: string;
+      /**
+       * Command to be exectuted and parameters passed to the command
+       */
+      command?: {
+          id: string;
+          params: Object | string;
+      };
+      /**
+       * A http url string
+       */
+      url?: string;
+  };
+  /**
+   * Provide a stringified version of the link that will be used on the CLI
+   */
+  toString(): string;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2373,10 +2373,10 @@
   dependencies:
     vue "^2.6.10"
 
-"@sap-devx/inquirer-gui@0.2.1":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@sap-devx/inquirer-gui/-/inquirer-gui-0.2.1.tgz#d96ed170f386a59c9b0f6f98d40bd7ed0ce3c626"
-  integrity sha512-4Xvxq/G/up2pjyYQcqwgbmf3qDbHoGKEcTf9z5LMSxNtExSc1yvhN6VzLqpFqpRr6BDF1qmRRKswMmS2cLNa1A==
+"@sap-devx/inquirer-gui@0.3.0":
+  version "0.3.0"
+  resolved "https://int.repositories.cloud.sap/artifactory/api/npm/build-milestones-npm/@sap-devx/inquirer-gui/-/inquirer-gui-0.3.0.tgz#aec200d40cc6d88381f73f773aecb5cf19229e08"
+  integrity sha512-kBNxug0cF6T/J8LrTTnh7oJ3wU1IQnZKkqmlTdoYLoYcWEXJ/ZVIKhcnzQCoR3mwE9T9XEMY4O0QEJBxDv9gTA==
   dependencies:
     strip-ansi "^6.0.0"
     vue "2.6.12"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2375,7 +2375,7 @@
 
 "@sap-devx/inquirer-gui@0.3.0":
   version "0.3.0"
-  resolved "https://int.repositories.cloud.sap/artifactory/api/npm/build-milestones-npm/@sap-devx/inquirer-gui/-/inquirer-gui-0.3.0.tgz#aec200d40cc6d88381f73f773aecb5cf19229e08"
+  resolved "https://registry.yarnpkg.com/@sap-devx/inquirer-gui/-/inquirer-gui-0.3.0.tgz#aec200d40cc6d88381f73f773aecb5cf19229e08"
   integrity sha512-kBNxug0cF6T/J8LrTTnh7oJ3wU1IQnZKkqmlTdoYLoYcWEXJ/ZVIKhcnzQCoR3mwE9T9XEMY4O0QEJBxDv9gTA==
   dependencies:
     strip-ansi "^6.0.0"


### PR DESCRIPTION
Adds support for execution of commands from inquirer-gui when the parameters are an object (previously only element attribute strings were supported).

This PR needs https://github.com/SAP/inquirer-gui/pull/475 to be published and updated with the new version to use this new feature.

Also adds new interface definition `IValidationLink` to support the new functionality when defining generator questions as TypeScript.