### PR TITLE
feat(yeoman-ui): provide ability to set the header title and info

### DIFF
--- a/packages/backend/src/vscode-youi-events.ts
+++ b/packages/backend/src/vscode-youi-events.ts
@@ -29,6 +29,11 @@ class YoUiAppWizard extends AppWizard {
   public showProgress(message?: string): void {
     this.events.showProgress(message);
   }
+
+  // Allows generators to update the App Wizard title
+  public setHeaderTitle(title: string, additionalInfo?: string): void {
+    this.events.setAppWizardHeaderTitle(title, additionalInfo);
+  }
 }
 
 export class VSCodeYouiEvents implements YouiEvents {
@@ -47,6 +52,13 @@ export class VSCodeYouiEvents implements YouiEvents {
     this.output = output;
     this.logger = getClassLogger("VSCodeYouiEvents");
     this.appWizard = new YoUiAppWizard(this);
+  }
+
+  public setAppWizardHeaderTitle(title: string, additionalInfo?: string): void {
+    void this.rpc.invoke("setHeaderTitle", [
+      title,
+      additionalInfo
+    ]);
   }
 
   public doGeneratorDone(

--- a/packages/backend/src/vscode-youi-events.ts
+++ b/packages/backend/src/vscode-youi-events.ts
@@ -55,10 +55,7 @@ export class VSCodeYouiEvents implements YouiEvents {
   }
 
   public setAppWizardHeaderTitle(title: string, additionalInfo?: string): void {
-    void this.rpc.invoke("setHeaderTitle", [
-      title,
-      additionalInfo
-    ]);
+    void this.rpc.invoke("setHeaderTitle", [title, additionalInfo]);
   }
 
   public doGeneratorDone(

--- a/packages/backend/src/webSocketServer/server-youi-events.ts
+++ b/packages/backend/src/webSocketServer/server-youi-events.ts
@@ -8,6 +8,9 @@ export class ServerYouiEvents implements YouiEvents {
   constructor(rpc: RpcCommon) {
     this.rpc = rpc;
   }
+  setAppWizardHeaderTitle(title: string, info?: string): void {
+    void this.rpc.invoke("setHeaderTitle", [title, info]);
+  }
 
   executeCommand(): Thenable<any> {
     return Promise.resolve();

--- a/packages/backend/src/yeomanui.ts
+++ b/packages/backend/src/yeomanui.ts
@@ -249,7 +249,7 @@ export class YeomanUI {
   }
 
   private resetHeaderTitle(): void {
-    void this.rpc.invoke("setHeaderTitle", [undefined, undefined]);
+    void this.youiEvents.setAppWizardHeaderTitle(undefined);
   }
 
   private setGenInWriting(gen: any) {

--- a/packages/backend/src/yeomanui.ts
+++ b/packages/backend/src/yeomanui.ts
@@ -249,7 +249,7 @@ export class YeomanUI {
   }
 
   private resetHeaderTitle(): void {
-    void this.rpc.invoke("setHeaderTitle", [undefined,undefined]);
+    void this.rpc.invoke("setHeaderTitle", [undefined, undefined]);
   }
 
   private setGenInWriting(gen: any) {

--- a/packages/backend/src/yeomanui.ts
+++ b/packages/backend/src/yeomanui.ts
@@ -248,6 +248,10 @@ export class YeomanUI {
     process.chdir(this.initialCwd);
   }
 
+  private resetHeaderTitle(): void {
+    void this.rpc.invoke("setHeaderTitle", [undefined,undefined]);
+  }
+
   private setGenInWriting(gen: any) {
     const genMethodName = "writing";
     const originalPrototype = Object.getPrototypeOf(gen);
@@ -313,6 +317,8 @@ export class YeomanUI {
     try {
       let generatorId: string = this.uiOptions.generator;
       if (!generatorId) {
+        // Reset current header title label, in case it has been updated by generators
+        this.resetHeaderTitle();
         const generators: IQuestionsPrompt = await this.getGeneratorsPrompt();
         await this._notifyGeneratorsInstall(this.uiOptions.installGens, true);
         const response: any = await this.rpc.invoke("showPrompt", [generators.questions, "select_generator"]);

--- a/packages/backend/src/youi-events.ts
+++ b/packages/backend/src/youi-events.ts
@@ -12,4 +12,5 @@ export interface YouiEvents {
   showProgress(message?: string): void;
   getAppWizard(): AppWizard;
   executeCommand(id: string, ...args: any[]): Thenable<any>;
+  setAppWizardHeaderTitle(title: string, info?: string): void;
 }

--- a/packages/backend/test/vscode-youi-events.spec.ts
+++ b/packages/backend/test/vscode-youi-events.spec.ts
@@ -223,6 +223,13 @@ describe("vscode-youi-events unit test", () => {
     events.doGeneratorInstall();
   });
 
+  it("setAppWizardHeaderTitle", () => {
+    const testTitle = 'testTitle';
+    const testInfo = 'testInfo';
+    rpcMock.expects("invoke").withExactArgs("setHeaderTitle", [testTitle, testInfo]);
+    events.setAppWizardHeaderTitle(testTitle, testInfo);
+  });
+
   describe("showProgress", () => {
     it("getAppWizard - no message received ---> show default Information message with Progress button", () => {
       const appWizard = events.getAppWizard();

--- a/packages/backend/test/vscode-youi-events.spec.ts
+++ b/packages/backend/test/vscode-youi-events.spec.ts
@@ -224,8 +224,8 @@ describe("vscode-youi-events unit test", () => {
   });
 
   it("setAppWizardHeaderTitle", () => {
-    const testTitle = 'testTitle';
-    const testInfo = 'testInfo';
+    const testTitle = "testTitle";
+    const testInfo = "testInfo";
     rpcMock.expects("invoke").withExactArgs("setHeaderTitle", [testTitle, testInfo]);
     events.setAppWizardHeaderTitle(testTitle, testInfo);
   });

--- a/packages/backend/test/yeomanui.spec.ts
+++ b/packages/backend/test/yeomanui.spec.ts
@@ -47,7 +47,7 @@ describe("yeomanui unit test", () => {
     public showProgress(): void {
       return;
     }
-    public setHeaderTitle(title: string, additionalInfo?: string): void {
+    public setHeaderTitle(): void {
       return;
     }
   }
@@ -68,7 +68,7 @@ describe("yeomanui unit test", () => {
     public executeCommand(): Thenable<any> {
       return;
     }
-    public setAppWizardHeaderTitle(title: string, additionalInfo?: string): void {
+    public setAppWizardHeaderTitle(): void {
       return;
     }
   }

--- a/packages/backend/test/yeomanui.spec.ts
+++ b/packages/backend/test/yeomanui.spec.ts
@@ -243,7 +243,7 @@ describe("yeomanui unit test", () => {
             on: () => "",
           },
         });
-      rpcMock.expects("invoke").withExactArgs("setHeaderTitle", [undefined, undefined]);
+      youiEventsMock.expects("setAppWizardHeaderTitle").withArgs(undefined);
       wsConfigMock.expects("get").withExactArgs("ApplicationWizard.TargetFolder").twice();
       rpcMock.expects("invoke").withArgs("showPrompt").resolves({ generator: "test1-project:app" });
       rpcMock.expects("invoke").withExactArgs("setGenInWriting", [false]).resolves();

--- a/packages/backend/test/yeomanui.spec.ts
+++ b/packages/backend/test/yeomanui.spec.ts
@@ -47,6 +47,9 @@ describe("yeomanui unit test", () => {
     public showProgress(): void {
       return;
     }
+    public setHeaderTitle(title: string, additionalInfo?: string): void {
+      return;
+    }
   }
   const appWizard: AppWizard = new TestAppWizard();
   class TestEvents implements YouiEvents {
@@ -63,6 +66,9 @@ describe("yeomanui unit test", () => {
       return;
     }
     public executeCommand(): Thenable<any> {
+      return;
+    }
+    public setAppWizardHeaderTitle(title: string, additionalInfo?: string): void {
       return;
     }
   }
@@ -237,6 +243,7 @@ describe("yeomanui unit test", () => {
             on: () => "",
           },
         });
+      rpcMock.expects("invoke").withExactArgs("setHeaderTitle", [undefined, undefined]);
       wsConfigMock.expects("get").withExactArgs("ApplicationWizard.TargetFolder").twice();
       rpcMock.expects("invoke").withArgs("showPrompt").resolves({ generator: "test1-project:app" });
       rpcMock.expects("invoke").withExactArgs("setGenInWriting", [false]).resolves();

--- a/packages/backend/test/youi-adapter.spec.ts
+++ b/packages/backend/test/youi-adapter.spec.ts
@@ -27,7 +27,7 @@ describe("YouiAdapter", () => {
     public executeCommand(): Thenable<any> {
       return;
     }
-    public setAppWizardHeaderTitle(title: string, additionalInfo?: string): void {
+    public setAppWizardHeaderTitle(): void {
       return;
     }
   }

--- a/packages/backend/test/youi-adapter.spec.ts
+++ b/packages/backend/test/youi-adapter.spec.ts
@@ -27,6 +27,9 @@ describe("YouiAdapter", () => {
     public executeCommand(): Thenable<any> {
       return;
     }
+    public setAppWizardHeaderTitle(title: string, additionalInfo?: string): void {
+      return;
+    }
   }
 
   class TestRpc implements IRpc {

--- a/packages/frontend/src/assets/css/globalStyles.css
+++ b/packages/frontend/src/assets/css/globalStyles.css
@@ -33,6 +33,11 @@ div.v-application .theme--light.v-btn.v-btn--disabled .v-icon {
   color: var(--vscode-button-foreground, #ffffff) !important;
 }
 
+div.v-application i.theme--light.v-icon {
+  font-size: 20px;
+  color: var(--vscode-foreground, #cccccc);
+}
+
 .v-application button.v-btn:not(.v-btn--flat):not(.v-btn--text):not(.v-btn--outlined):hover {
   background-color: var(--vscode-button-hoverBackground, #1177bb);
   border-color: var(--vscode-button-hoverBackground, #1177bb);

--- a/packages/frontend/src/assets/css/globalStyles.css
+++ b/packages/frontend/src/assets/css/globalStyles.css
@@ -33,11 +33,6 @@ div.v-application .theme--light.v-btn.v-btn--disabled .v-icon {
   color: var(--vscode-button-foreground, #ffffff) !important;
 }
 
-div.v-application i.theme--light.v-icon {
-  font-size: 20px;
-  color: var(--vscode-foreground, #cccccc);
-}
-
 .v-application button.v-btn:not(.v-btn--flat):not(.v-btn--text):not(.v-btn--outlined):hover {
   background-color: var(--vscode-button-hoverBackground, #1177bb);
   border-color: var(--vscode-button-hoverBackground, #1177bb);

--- a/packages/frontend/src/components/Header.vue
+++ b/packages/frontend/src/components/Header.vue
@@ -4,7 +4,7 @@
       <v-toolbar-title v-bind="attrs" v-on="on">{{ headerTitle }}</v-toolbar-title>
       <v-tooltip v-if="headerInfo" bottom>
         <template v-slot:activator="{ on }">
-          <v-icon v-on="on">mdi-information-outline</v-icon>
+          <v-icon id="header-info-icon" v-on="on" >mdi-information-outline</v-icon>
         </template>
         <span>{{ headerInfo }}</span>
       </v-tooltip>
@@ -48,8 +48,8 @@ header.v-app-bar.v-toolbar {
   box-shadow: none;
   background-color: var(--vscode-editor-background, #1e1e1e) !important;
 }
-header.v-app-bar.v-toolbar .v-icon {
-  padding: 9px 5px 6px;
-  opacity: 0.55;
+#header-info-icon {
+  padding: 9px 12px 6px;
+  color: var(--vscode-notificationsInfoIcon-foreground, #5EADF2);
 }
 </style>

--- a/packages/frontend/src/components/Header.vue
+++ b/packages/frontend/src/components/Header.vue
@@ -4,7 +4,7 @@
       <v-toolbar-title v-bind="attrs" v-on="on">{{ headerTitle }}</v-toolbar-title>
       <v-tooltip v-if="headerInfo" bottom>
         <template v-slot:activator="{ on }">
-          <v-icon id="header-info-icon" v-on="on" >mdi-information-outline</v-icon>
+          <v-icon id="header-info-icon" v-on="on">mdi-information-outline</v-icon>
         </template>
         <span>{{ headerInfo }}</span>
       </v-tooltip>
@@ -50,6 +50,6 @@ header.v-app-bar.v-toolbar {
 }
 #header-info-icon {
   padding: 9px 12px 6px;
-  color: var(--vscode-notificationsInfoIcon-foreground, #5EADF2);
+  color: var(--vscode-notificationsInfoIcon-foreground, #5eadf2);
 }
 </style>

--- a/packages/frontend/src/components/Header.vue
+++ b/packages/frontend/src/components/Header.vue
@@ -3,7 +3,7 @@
     <v-app-bar class="elevation-0">
       <v-toolbar-title v-bind="attrs" v-on="on">{{ headerTitle }}</v-toolbar-title>
       <v-tooltip v-if="headerInfo" bottom>
-        <template v-slot:activator="{ on, attrs }">
+        <template v-slot:activator="{ on }">
           <v-icon v-on="on">mdi-information-outline</v-icon>
         </template>
         <span>{{ headerInfo }}</span>

--- a/packages/frontend/src/components/Header.vue
+++ b/packages/frontend/src/components/Header.vue
@@ -6,7 +6,7 @@
         <template v-slot:activator="{ on, attrs }">
           <v-icon v-on="on">mdi-information-outline</v-icon>
         </template>
-       <span>{{ headerInfo }}</span>
+        <span>{{ headerInfo }}</span>
       </v-tooltip>
       <v-spacer></v-spacer>
       <v-btn v-if="isGeneric" text x-small color="primary" @click="openExploreGenerators">
@@ -50,6 +50,6 @@ header.v-app-bar.v-toolbar {
 }
 header.v-app-bar.v-toolbar .v-icon {
   padding: 9px 5px 6px;
-  opacity: .55;
+  opacity: 0.55;
 }
 </style>

--- a/packages/frontend/src/components/Header.vue
+++ b/packages/frontend/src/components/Header.vue
@@ -49,6 +49,7 @@ header.v-app-bar.v-toolbar {
   background-color: var(--vscode-editor-background, #1e1e1e) !important;
 }
 #header-info-icon {
+  font-size: 20px;
   padding: 9px 12px 6px;
   color: var(--vscode-notificationsInfoIcon-foreground, #5eadf2);
 }

--- a/packages/frontend/src/components/Header.vue
+++ b/packages/frontend/src/components/Header.vue
@@ -1,7 +1,13 @@
 <template>
   <div>
     <v-app-bar class="elevation-0">
-      <v-toolbar-title>{{ headerTitle }}</v-toolbar-title>
+      <v-toolbar-title v-bind="attrs" v-on="on">{{ headerTitle }}</v-toolbar-title>
+      <v-tooltip v-if="headerInfo" bottom>
+        <template v-slot:activator="{ on, attrs }">
+          <v-icon v-on="on">mdi-information-outline</v-icon>
+        </template>
+       <span>{{ headerInfo }}</span>
+      </v-tooltip>
       <v-spacer></v-spacer>
       <v-btn v-if="isGeneric" text x-small color="primary" @click="openExploreGenerators">
         <v-card-text> Explore and Install Generators... </v-card-text>
@@ -18,7 +24,7 @@
 <script>
 export default {
   name: "Header",
-  props: ["headerTitle", "stepName", "isInVsCode", "rpc", "isGeneric"],
+  props: ["headerTitle", "stepName", "isInVsCode", "rpc", "isGeneric", "headerInfo"],
   methods: {
     collapseOutput() {
       this.rpc.invoke("toggleOutput", [{}]);
@@ -41,5 +47,9 @@ header.v-app-bar.v-toolbar {
   border-bottom: 1px solid var(--vscode-editorWidget-background, #252526);
   box-shadow: none;
   background-color: var(--vscode-editor-background, #1e1e1e) !important;
+}
+header.v-app-bar.v-toolbar .v-icon {
+  padding: 9px 5px 6px;
+  opacity: .55;
 }
 </style>

--- a/packages/frontend/src/youi/App.vue
+++ b/packages/frontend/src/youi/App.vue
@@ -24,27 +24,14 @@
 
     <v-row class="main-row ma-0 pa-0">
       <v-col class="left-col ma-0 pa-0" cols="3">
-        <Navigation
-          v-if="prompts.length"
-          :promptIndex="promptIndex"
-          :prompts="prompts"
-          @onGotoStep="gotoStep"
-        />
+        <Navigation v-if="prompts.length" :promptIndex="promptIndex" :prompts="prompts" @onGotoStep="gotoStep" />
       </v-col>
       <v-col cols="9" class="right-col">
         <v-row class="prompts-col">
           <v-col>
-            <Done
-              v-if="isDone"
-              :doneStatus="doneStatus"
-              :doneMessage="doneMessage"
-              :donePath="donePath"
-            />
+            <Done v-if="isDone" :doneStatus="doneStatus" :doneMessage="doneMessage" :donePath="donePath" />
 
-            <PromptInfo
-              v-if="currentPrompt && !isDone"
-              :currentPrompt="currentPrompt"
-            />
+            <PromptInfo v-if="currentPrompt && !isDone" :currentPrompt="currentPrompt" />
             <v-slide-x-transition>
               <Form
                 ref="form"
@@ -76,32 +63,16 @@
             >
               <v-icon left>mdi-chevron-left</v-icon>{{ backButtonText }}
             </v-btn>
-            <v-btn
-              id="next"
-              :disabled="!stepValidated"
-              @click="next"
-              style="min-width: 90px"
-            >
+            <v-btn id="next" :disabled="!stepValidated" @click="next" style="min-width: 90px">
               {{ nextButtonText }}
-              <v-icon right v-if="nextButtonText !== `Finish`"
-                >mdi-chevron-right</v-icon
-              >
+              <v-icon right v-if="nextButtonText !== `Finish`">mdi-chevron-right</v-icon>
             </v-btn>
           </div>
           <div class="prompt-message" v-if="toShowPromptMessage">
-            <img
-              style="vertical-align: middle; padding-left: 12px"
-              :src="promptMessageIcon"
-              alt=""
-            />
-            <v-tooltip
-              right
-              :disabled="promptMessageToDisplay.length < this.messageMaxLength"
-            >
+            <img style="vertical-align: middle; padding-left: 12px" :src="promptMessageIcon" alt="" />
+            <v-tooltip right :disabled="promptMessageToDisplay.length < this.messageMaxLength">
               <template v-slot:activator="{ on }">
-                <span :class="promptMessageClass" v-on="on">{{
-                  showPrompt
-                }}</span>
+                <span :class="promptMessageClass" v-on="on">{{ showPrompt }}</span>
               </template>
               <span>{{ promptMessageToDisplay }}</span>
             </v-tooltip>
@@ -113,11 +84,7 @@
 
     <!-- TODO Handle scroll of above content when console is visible. low priority because it is for localhost console only -->
     <v-card :class="consoleClass" v-show="showConsole">
-      <v-footer
-        absolute
-        class="font-weight-medium"
-        style="max-height: 300px; overflow-y: auto"
-      >
+      <v-footer absolute class="font-weight-medium" style="max-height: 300px; overflow-y: auto">
         <v-col class cols="12">
           <div id="logArea" placeholder="No log entry">{{ logText }}</div>
         </v-col>
@@ -216,8 +183,7 @@ export default {
     },
     nextButtonText() {
       if (
-        (!this.selectGeneratorPromptExists() &&
-          this.promptIndex === _size(this.promptsInfoToDisplay) - 1) ||
+        (!this.selectGeneratorPromptExists() && this.promptIndex === _size(this.promptsInfoToDisplay) - 1) ||
         (this.selectGeneratorPromptExists() &&
           this.promptIndex > 0 &&
           this.promptIndex === _size(this.promptsInfoToDisplay)) ||
@@ -231,9 +197,7 @@ export default {
     },
     isLoadingColor() {
       return (
-        getComputedStyle(document.documentElement).getPropertyValue(
-          "--vscode-progressBar-background"
-        ) || "#0e70c0"
+        getComputedStyle(document.documentElement).getPropertyValue("--vscode-progressBar-background") || "#0e70c0"
       );
     },
     headerTitle() {
@@ -241,9 +205,7 @@ export default {
       if (!_isEmpty(this.headerTitleProvided)) {
         return this.headerTitleProvided;
       }
-      const titleSuffix = _isEmpty(this.generatorPrettyName)
-        ? ""
-        : ` - ${this.generatorPrettyName}`;
+      const titleSuffix = _isEmpty(this.generatorPrettyName) ? "" : ` - ${this.generatorPrettyName}`;
       return `${_get(this.messages, "yeoman_ui_title")}${titleSuffix}`;
     },
     currentPrompt() {
@@ -283,9 +245,7 @@ export default {
     showPromptMessage(message, type, image) {
       this.promptMessageToDisplay = message;
       this.showPrompt =
-        message.length < this.messageMaxLength
-          ? message
-          : message.substr(0, this.messageMaxLength) + "...";
+        message.length < this.messageMaxLength ? message : message.substr(0, this.messageMaxLength) + "...";
       this.toShowPromptMessage = true;
       this.promptMessageIcon = image;
 
@@ -301,8 +261,7 @@ export default {
       this.expectedShowBusyIndicator =
         _isEmpty(this.prompts) ||
         (this.currentPrompt &&
-          (this.currentPrompt.status === PENDING ||
-            this.currentPrompt.status === EVALUATING) &&
+          (this.currentPrompt.status === PENDING || this.currentPrompt.status === EVALUATING) &&
           !this.isDone);
       if (this.expectedShowBusyIndicator) {
         setTimeout(() => {
@@ -354,9 +313,7 @@ export default {
       }
     },
     getInProgressStepName() {
-      return this.isWriting
-        ? _get(this.messages, "step_is_generating")
-        : _get(this.messages, "step_is_pending");
+      return this.isWriting ? _get(this.messages, "step_is_generating") : _get(this.messages, "step_is_pending");
     },
     next() {
       if (this.resolve === null) {
@@ -378,22 +335,17 @@ export default {
 
       this.promptIndex++;
       this.prompts[this.promptIndex - 1].active = false;
-
       this.prompts[this.promptIndex].active = true;
     },
     onAnswered(answers, issues) {
       const currentPrompt = this.currentPrompt;
       if (currentPrompt) {
         this.stepValidated =
-          currentPrompt.status === PENDING || _isEmpty(currentPrompt.questions)
-            ? false
-            : _isNil(issues);
+          currentPrompt.status === PENDING || _isEmpty(currentPrompt.questions) ? false : _isNil(issues);
 
         currentPrompt.answers = answers;
         if (currentPrompt.answers.generator) {
-          this.isToolsSuiteTypeGen = this.isToolsSuiteType(
-            currentPrompt.answers.generator
-          );
+          this.isToolsSuiteTypeGen = this.isToolsSuiteType(currentPrompt.answers.generator);
         }
         if (currentPrompt.status === EVALUATING) {
           currentPrompt.status = undefined;
@@ -409,10 +361,7 @@ export default {
         const choices = _compact(_get(generatorQuestion, "choices"));
         if (choices) {
           const isToolsSuiteGen = _find(choices, (choice) => {
-            return (
-              _get(choice, "isToolsSuiteType") === true &&
-              _get(choice, "value") === genName
-            );
+            return _get(choice, "isToolsSuiteType") === true && _get(choice, "value") === genName;
           });
           return _isEmpty(isToolsSuiteGen) === false;
         }
@@ -488,11 +437,7 @@ export default {
               }
 
               try {
-                return await that.rpc.invoke("evaluateMethod", [
-                  args,
-                  question.name,
-                  prop,
-                ]);
+                return await that.rpc.invoke("evaluateMethod", [args, question.name, prop]);
               } catch (e) {
                 that.showBusyIndicator = false;
                 throw e;
@@ -532,8 +477,7 @@ export default {
       }
 
       if (this.nextButtonText === "Finish" && this.isToolsSuiteTypeGen) {
-        const message =
-          "The generated project will not open in a stand-alone folder.";
+        const message = "The generated project will not open in a stand-alone folder.";
         const image =
           "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4NCjwhRE9DVFlQRSBzdmcgUFVCTElDICItLy9XM0MvL0RURCBTVkcgMS4xLy9FTiIgImh0dHA6Ly93d3cudzMub3JnL0dyYXBoaWNzL1NWRy8xLjEvRFREL3N2ZzExLmR0ZCI+DQo8c3ZnIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHdpZHRoPSIxNyIgaGVpZ2h0PSIxNyIgdmlld0JveD0iMCAwIDE3IDE3Ij4NCiAgPGRlZnM+DQogICAgPGNsaXBQYXRoIGlkPSJjbGlwLWluZm9fdmNvZGUiPg0KICAgICAgPHJlY3Qgd2lkdGg9IjE3IiBoZWlnaHQ9IjE3Ii8+DQogICAgPC9jbGlwUGF0aD4NCiAgPC9kZWZzPg0KICA8ZyBpZD0iaW5mb192Y29kZSIgY2xpcC1wYXRoPSJ1cmwoI2NsaXAtaW5mb192Y29kZSkiPg0KICAgIDxnIGlkPSJHcm91cF8zNTQ0IiBkYXRhLW5hbWU9Ikdyb3VwIDM1NDQiPg0KICAgICAgPGcgaWQ9Ikdyb3VwXzM1NDMiIGRhdGEtbmFtZT0iR3JvdXAgMzU0MyI+DQogICAgICAgIDxnIGlkPSJHcm91cF8zNTQyIiBkYXRhLW5hbWU9Ikdyb3VwIDM1NDIiPg0KICAgICAgICAgIDxnIGlkPSJFbGxpcHNlXzU0IiBkYXRhLW5hbWU9IkVsbGlwc2UgNTQiIGZpbGw9Im5vbmUiIHN0cm9rZT0iIzZmYmFmNyIgc3Ryb2tlLXdpZHRoPSIxLjUiPg0KICAgICAgICAgICAgPGNpcmNsZSBjeD0iOC41IiBjeT0iOC41IiByPSI4LjUiIHN0cm9rZT0ibm9uZSIvPg0KICAgICAgICAgICAgPGNpcmNsZSBjeD0iOC41IiBjeT0iOC41IiByPSI3Ljc1IiBmaWxsPSJub25lIi8+DQogICAgICAgICAgPC9nPg0KICAgICAgICAgIDxwYXRoIGlkPSJQYXRoXzE2NDAiIGRhdGEtbmFtZT0iUGF0aCAxNjQwIiBkPSJNMTg1Mi41LTI3NzkuNzMxdjQuNTA2IiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgtMTg0NCAyNzg3Ljc1KSIgZmlsbD0ibm9uZSIgc3Ryb2tlPSIjNmZiYWY3IiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS13aWR0aD0iMS41Ii8+DQogICAgICAgICAgPHBhdGggaWQ9IlBhdGhfMTY0MSIgZGF0YS1uYW1lPSJQYXRoIDE2NDEiIGQ9Ik0xODUyLjUtMjc3NC43MzFoMCIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoLTE4NDQgMjc4MCkiIGZpbGw9Im5vbmUiIHN0cm9rZT0iIzZmYmFmNyIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIiBzdHJva2Utd2lkdGg9IjIiLz4NCiAgICAgICAgPC9nPg0KICAgICAgPC9nPg0KICAgIDwvZz4NCiAgPC9nPg0KPC9zdmc+DQo=";
         this.showPromptMessage(message, Severity.information, image);
@@ -559,13 +503,8 @@ export default {
         promptDescription = _get(this.messages, "select_generator_description");
         promptName = _get(this.messages, "select_generator_name");
       } else {
-        const promptIndex = this.selectGeneratorPromptExists()
-          ? this.promptIndex - 1
-          : this.promptIndex;
-        const promptToDisplay = _get(
-          this.promptsInfoToDisplay,
-          `[${promptIndex}]`
-        );
+        const promptIndex = this.selectGeneratorPromptExists() ? this.promptIndex - 1 : this.promptIndex;
+        const promptToDisplay = _get(this.promptsInfoToDisplay, `[${promptIndex}]`);
         promptDescription = _get(promptToDisplay, "description", "");
         promptName = _get(promptToDisplay, "name", name);
       }
@@ -683,9 +622,7 @@ export default {
       this.registerPlugin(TilesPlugin);
       this.registerPlugin(LabelPlugin);
 
-      this.isInVsCode()
-        ? (this.consoleClass = "consoleClassHidden")
-        : (this.consoleClass = "consoleClassVisible");
+      this.isInVsCode() ? (this.consoleClass = "consoleClassHidden") : (this.consoleClass = "consoleClassVisible");
     },
     reload() {
       const dataObj = initialState();

--- a/packages/frontend/src/youi/App.vue
+++ b/packages/frontend/src/youi/App.vue
@@ -14,6 +14,7 @@
       id="header"
       v-if="prompts.length"
       :headerTitle="headerTitle"
+      :headerInfo="headerInfo"
       :stepName="promptIndex < prompts.length ? prompts[promptIndex].name : ''"
       :rpc="rpc"
       :isInVsCode="isInVsCode()"
@@ -23,14 +24,27 @@
 
     <v-row class="main-row ma-0 pa-0">
       <v-col class="left-col ma-0 pa-0" cols="3">
-        <Navigation v-if="prompts.length" :promptIndex="promptIndex" :prompts="prompts" @onGotoStep="gotoStep" />
+        <Navigation
+          v-if="prompts.length"
+          :promptIndex="promptIndex"
+          :prompts="prompts"
+          @onGotoStep="gotoStep"
+        />
       </v-col>
       <v-col cols="9" class="right-col">
         <v-row class="prompts-col">
           <v-col>
-            <Done v-if="isDone" :doneStatus="doneStatus" :doneMessage="doneMessage" :donePath="donePath" />
+            <Done
+              v-if="isDone"
+              :doneStatus="doneStatus"
+              :doneMessage="doneMessage"
+              :donePath="donePath"
+            />
 
-            <PromptInfo v-if="currentPrompt && !isDone" :currentPrompt="currentPrompt" />
+            <PromptInfo
+              v-if="currentPrompt && !isDone"
+              :currentPrompt="currentPrompt"
+            />
             <v-slide-x-transition>
               <Form
                 ref="form"
@@ -62,16 +76,32 @@
             >
               <v-icon left>mdi-chevron-left</v-icon>{{ backButtonText }}
             </v-btn>
-            <v-btn id="next" :disabled="!stepValidated" @click="next" style="min-width: 90px">
+            <v-btn
+              id="next"
+              :disabled="!stepValidated"
+              @click="next"
+              style="min-width: 90px"
+            >
               {{ nextButtonText }}
-              <v-icon right v-if="nextButtonText !== `Finish`">mdi-chevron-right</v-icon>
+              <v-icon right v-if="nextButtonText !== `Finish`"
+                >mdi-chevron-right</v-icon
+              >
             </v-btn>
           </div>
           <div class="prompt-message" v-if="toShowPromptMessage">
-            <img style="vertical-align: middle; padding-left: 12px" :src="promptMessageIcon" alt="" />
-            <v-tooltip right :disabled="promptMessageToDisplay.length < this.messageMaxLength">
+            <img
+              style="vertical-align: middle; padding-left: 12px"
+              :src="promptMessageIcon"
+              alt=""
+            />
+            <v-tooltip
+              right
+              :disabled="promptMessageToDisplay.length < this.messageMaxLength"
+            >
               <template v-slot:activator="{ on }">
-                <span :class="promptMessageClass" v-on="on">{{ showPrompt }}</span>
+                <span :class="promptMessageClass" v-on="on">{{
+                  showPrompt
+                }}</span>
               </template>
               <span>{{ promptMessageToDisplay }}</span>
             </v-tooltip>
@@ -83,7 +113,11 @@
 
     <!-- TODO Handle scroll of above content when console is visible. low priority because it is for localhost console only -->
     <v-card :class="consoleClass" v-show="showConsole">
-      <v-footer absolute class="font-weight-medium" style="max-height: 300px; overflow-y: auto">
+      <v-footer
+        absolute
+        class="font-weight-medium"
+        style="max-height: 300px; overflow-y: auto"
+      >
         <v-col class cols="12">
           <div id="logArea" placeholder="No log entry">{{ logText }}</div>
         </v-col>
@@ -155,6 +189,8 @@ function initialState() {
     promptMessageClass: "",
     promptMessageIcon: null,
     messageMaxLength: 100,
+    headerTitleProvided: "",
+    headerInfo: "",
   };
 }
 
@@ -180,7 +216,8 @@ export default {
     },
     nextButtonText() {
       if (
-        (!this.selectGeneratorPromptExists() && this.promptIndex === _size(this.promptsInfoToDisplay) - 1) ||
+        (!this.selectGeneratorPromptExists() &&
+          this.promptIndex === _size(this.promptsInfoToDisplay) - 1) ||
         (this.selectGeneratorPromptExists() &&
           this.promptIndex > 0 &&
           this.promptIndex === _size(this.promptsInfoToDisplay)) ||
@@ -194,11 +231,19 @@ export default {
     },
     isLoadingColor() {
       return (
-        getComputedStyle(document.documentElement).getPropertyValue("--vscode-progressBar-background") || "#0e70c0"
+        getComputedStyle(document.documentElement).getPropertyValue(
+          "--vscode-progressBar-background"
+        ) || "#0e70c0"
       );
     },
     headerTitle() {
-      const titleSuffix = _isEmpty(this.generatorPrettyName) ? "" : ` - ${this.generatorPrettyName}`;
+      // If the header title is externally set then this overrides the default behaviour
+      if (!_isEmpty(this.headerTitleProvided)) {
+        return this.headerTitleProvided;
+      }
+      const titleSuffix = _isEmpty(this.generatorPrettyName)
+        ? ""
+        : ` - ${this.generatorPrettyName}`;
       return `${_get(this.messages, "yeoman_ui_title")}${titleSuffix}`;
     },
     currentPrompt() {
@@ -238,7 +283,9 @@ export default {
     showPromptMessage(message, type, image) {
       this.promptMessageToDisplay = message;
       this.showPrompt =
-        message.length < this.messageMaxLength ? message : message.substr(0, this.messageMaxLength) + "...";
+        message.length < this.messageMaxLength
+          ? message
+          : message.substr(0, this.messageMaxLength) + "...";
       this.toShowPromptMessage = true;
       this.promptMessageIcon = image;
 
@@ -254,7 +301,8 @@ export default {
       this.expectedShowBusyIndicator =
         _isEmpty(this.prompts) ||
         (this.currentPrompt &&
-          (this.currentPrompt.status === PENDING || this.currentPrompt.status === EVALUATING) &&
+          (this.currentPrompt.status === PENDING ||
+            this.currentPrompt.status === EVALUATING) &&
           !this.isDone);
       if (this.expectedShowBusyIndicator) {
         setTimeout(() => {
@@ -294,6 +342,10 @@ export default {
         this.reject(error);
       }
     },
+    setHeaderTitle(title, info) {
+      this.headerTitleProvided = title;
+      this.headerInfo = info;
+    },
     setGenInWriting(value) {
       this.isWriting = value;
       this.showButtons = !this.isWriting;
@@ -302,7 +354,9 @@ export default {
       }
     },
     getInProgressStepName() {
-      return this.isWriting ? _get(this.messages, "step_is_generating") : _get(this.messages, "step_is_pending");
+      return this.isWriting
+        ? _get(this.messages, "step_is_generating")
+        : _get(this.messages, "step_is_pending");
     },
     next() {
       if (this.resolve === null) {
@@ -324,17 +378,22 @@ export default {
 
       this.promptIndex++;
       this.prompts[this.promptIndex - 1].active = false;
+
       this.prompts[this.promptIndex].active = true;
     },
     onAnswered(answers, issues) {
       const currentPrompt = this.currentPrompt;
       if (currentPrompt) {
         this.stepValidated =
-          currentPrompt.status === PENDING || _isEmpty(currentPrompt.questions) ? false : _isNil(issues);
+          currentPrompt.status === PENDING || _isEmpty(currentPrompt.questions)
+            ? false
+            : _isNil(issues);
 
         currentPrompt.answers = answers;
         if (currentPrompt.answers.generator) {
-          this.isToolsSuiteTypeGen = this.isToolsSuiteType(currentPrompt.answers.generator);
+          this.isToolsSuiteTypeGen = this.isToolsSuiteType(
+            currentPrompt.answers.generator
+          );
         }
         if (currentPrompt.status === EVALUATING) {
           currentPrompt.status = undefined;
@@ -350,7 +409,10 @@ export default {
         const choices = _compact(_get(generatorQuestion, "choices"));
         if (choices) {
           const isToolsSuiteGen = _find(choices, (choice) => {
-            return _get(choice, "isToolsSuiteType") === true && _get(choice, "value") === genName;
+            return (
+              _get(choice, "isToolsSuiteType") === true &&
+              _get(choice, "value") === genName
+            );
           });
           return _isEmpty(isToolsSuiteGen) === false;
         }
@@ -426,7 +488,11 @@ export default {
               }
 
               try {
-                return await that.rpc.invoke("evaluateMethod", [args, question.name, prop]);
+                return await that.rpc.invoke("evaluateMethod", [
+                  args,
+                  question.name,
+                  prop,
+                ]);
               } catch (e) {
                 that.showBusyIndicator = false;
                 throw e;
@@ -466,7 +532,8 @@ export default {
       }
 
       if (this.nextButtonText === "Finish" && this.isToolsSuiteTypeGen) {
-        const message = "The generated project will not open in a stand-alone folder.";
+        const message =
+          "The generated project will not open in a stand-alone folder.";
         const image =
           "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4NCjwhRE9DVFlQRSBzdmcgUFVCTElDICItLy9XM0MvL0RURCBTVkcgMS4xLy9FTiIgImh0dHA6Ly93d3cudzMub3JnL0dyYXBoaWNzL1NWRy8xLjEvRFREL3N2ZzExLmR0ZCI+DQo8c3ZnIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHdpZHRoPSIxNyIgaGVpZ2h0PSIxNyIgdmlld0JveD0iMCAwIDE3IDE3Ij4NCiAgPGRlZnM+DQogICAgPGNsaXBQYXRoIGlkPSJjbGlwLWluZm9fdmNvZGUiPg0KICAgICAgPHJlY3Qgd2lkdGg9IjE3IiBoZWlnaHQ9IjE3Ii8+DQogICAgPC9jbGlwUGF0aD4NCiAgPC9kZWZzPg0KICA8ZyBpZD0iaW5mb192Y29kZSIgY2xpcC1wYXRoPSJ1cmwoI2NsaXAtaW5mb192Y29kZSkiPg0KICAgIDxnIGlkPSJHcm91cF8zNTQ0IiBkYXRhLW5hbWU9Ikdyb3VwIDM1NDQiPg0KICAgICAgPGcgaWQ9Ikdyb3VwXzM1NDMiIGRhdGEtbmFtZT0iR3JvdXAgMzU0MyI+DQogICAgICAgIDxnIGlkPSJHcm91cF8zNTQyIiBkYXRhLW5hbWU9Ikdyb3VwIDM1NDIiPg0KICAgICAgICAgIDxnIGlkPSJFbGxpcHNlXzU0IiBkYXRhLW5hbWU9IkVsbGlwc2UgNTQiIGZpbGw9Im5vbmUiIHN0cm9rZT0iIzZmYmFmNyIgc3Ryb2tlLXdpZHRoPSIxLjUiPg0KICAgICAgICAgICAgPGNpcmNsZSBjeD0iOC41IiBjeT0iOC41IiByPSI4LjUiIHN0cm9rZT0ibm9uZSIvPg0KICAgICAgICAgICAgPGNpcmNsZSBjeD0iOC41IiBjeT0iOC41IiByPSI3Ljc1IiBmaWxsPSJub25lIi8+DQogICAgICAgICAgPC9nPg0KICAgICAgICAgIDxwYXRoIGlkPSJQYXRoXzE2NDAiIGRhdGEtbmFtZT0iUGF0aCAxNjQwIiBkPSJNMTg1Mi41LTI3NzkuNzMxdjQuNTA2IiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgtMTg0NCAyNzg3Ljc1KSIgZmlsbD0ibm9uZSIgc3Ryb2tlPSIjNmZiYWY3IiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS13aWR0aD0iMS41Ii8+DQogICAgICAgICAgPHBhdGggaWQ9IlBhdGhfMTY0MSIgZGF0YS1uYW1lPSJQYXRoIDE2NDEiIGQ9Ik0xODUyLjUtMjc3NC43MzFoMCIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoLTE4NDQgMjc4MCkiIGZpbGw9Im5vbmUiIHN0cm9rZT0iIzZmYmFmNyIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIiBzdHJva2Utd2lkdGg9IjIiLz4NCiAgICAgICAgPC9nPg0KICAgICAgPC9nPg0KICAgIDwvZz4NCiAgPC9nPg0KPC9zdmc+DQo=";
         this.showPromptMessage(message, Severity.information, image);
@@ -492,8 +559,13 @@ export default {
         promptDescription = _get(this.messages, "select_generator_description");
         promptName = _get(this.messages, "select_generator_name");
       } else {
-        const promptIndex = this.selectGeneratorPromptExists() ? this.promptIndex - 1 : this.promptIndex;
-        const promptToDisplay = _get(this.promptsInfoToDisplay, `[${promptIndex}]`);
+        const promptIndex = this.selectGeneratorPromptExists()
+          ? this.promptIndex - 1
+          : this.promptIndex;
+        const promptToDisplay = _get(
+          this.promptsInfoToDisplay,
+          `[${promptIndex}]`
+        );
         promptDescription = _get(promptToDisplay, "description", "");
         promptName = _get(promptToDisplay, "name", name);
       }
@@ -567,6 +639,7 @@ export default {
         "isGeneratorsPrompt",
         "setGenInWriting",
         "showPromptMessage",
+        "setHeaderTitle",
       ];
       _forEach(functions, (funcName) => {
         this.rpc.registerMethod({
@@ -610,7 +683,9 @@ export default {
       this.registerPlugin(TilesPlugin);
       this.registerPlugin(LabelPlugin);
 
-      this.isInVsCode() ? (this.consoleClass = "consoleClassHidden") : (this.consoleClass = "consoleClassVisible");
+      this.isInVsCode()
+        ? (this.consoleClass = "consoleClassHidden")
+        : (this.consoleClass = "consoleClassVisible");
     },
     reload() {
       const dataObj = initialState();

--- a/packages/frontend/test/App.spec.js
+++ b/packages/frontend/test/App.spec.js
@@ -919,8 +919,8 @@ describe("App.vue", () => {
     });
 
     it("setHeaderTtle overrides", () => {
-      const testTitle = 'testHeaderTitle';
-      const testInfo = 'testHeaderInfo';
+      const testTitle = "testHeaderTitle";
+      const testInfo = "testHeaderInfo";
       wrapper = initComponent(App);
       wrapper.vm.setHeaderTitle(testTitle, testInfo);
       expect(wrapper.vm.headerTitle).toEqual(testTitle);

--- a/packages/frontend/test/App.spec.js
+++ b/packages/frontend/test/App.spec.js
@@ -917,6 +917,15 @@ describe("App.vue", () => {
       wrapper.vm.$data.messages = { yeoman_ui_title: "yeoman_ui_title" };
       expect(wrapper.vm.headerTitle).toEqual("yeoman_ui_title - testGeneratorPrettyName");
     });
+
+    it("setHeaderTtle overrides", () => {
+      const testTitle = 'testHeaderTitle';
+      const testInfo = 'testHeaderInfo';
+      wrapper = initComponent(App);
+      wrapper.vm.setHeaderTitle(testTitle, testInfo);
+      expect(wrapper.vm.headerTitle).toEqual(testTitle);
+      expect(wrapper.vm.headerInfo).toEqual(testInfo);
+    });
   });
 
   describe("setGenInWriting", () => {

--- a/packages/frontend/test/components/Header.spec.js
+++ b/packages/frontend/test/components/Header.spec.js
@@ -17,7 +17,7 @@ describe("Header.vue", () => {
 
   test("component props", () => {
     wrapper = initComponent(Header);
-    expect(_.keys(wrapper.props())).toHaveLength(5);
+    expect(_.keys(wrapper.props())).toHaveLength(6);
   });
 
   test("generator brand", () => {
@@ -25,6 +25,14 @@ describe("Header.vue", () => {
     wrapper = initComponent(Header, { headerTitle: testGen });
     expect(wrapper.find("v-toolbar-title-stub").text()).toBe(testGen);
     expect(wrapper.find("v-icon-stub").text()).toBe("mdi-console");
+  });
+
+  test("set title and info", () => {
+    const testTitle = "test title";
+    const testInfo = "test info";
+    wrapper = initComponent(Header, { headerTitle: testTitle, headerInfo: testInfo });
+    expect(wrapper.find("v-toolbar-title-stub").text()).toBe(testTitle);
+    expect(wrapper.find('v-tooltip-stub span').text()).toBe(testInfo);
   });
 
   test("click triggers collapseOutput method", async () => {

--- a/packages/frontend/test/components/Header.spec.js
+++ b/packages/frontend/test/components/Header.spec.js
@@ -32,7 +32,7 @@ describe("Header.vue", () => {
     const testInfo = "test info";
     wrapper = initComponent(Header, { headerTitle: testTitle, headerInfo: testInfo });
     expect(wrapper.find("v-toolbar-title-stub").text()).toBe(testTitle);
-    expect(wrapper.find('v-tooltip-stub span').text()).toBe(testInfo);
+    expect(wrapper.find("v-tooltip-stub span").text()).toBe(testInfo);
   });
 
   test("click triggers collapseOutput method", async () => {

--- a/packages/generator-foodq/generators/app2/index.js
+++ b/packages/generator-foodq/generators/app2/index.js
@@ -12,6 +12,10 @@ module.exports = class extends Generator {
     this.appWizard = opts.appWizard;
     this.parentPromptsQuantity = _.size(this.prompts);
 
+    if (this.appWizard) {
+      opts.appWizard.setHeaderTitle(this.rootGeneratorName(), `Generator Version: ${this.rootGeneratorVersion()}`);
+    }
+
     this.option("silent", { type: Boolean });
     const silent = opts.silent || _.get(this.options, "silent", false);
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -3,6 +3,7 @@ export abstract class AppWizard {
   abstract showWarning(message: string, type: MessageType): void;
   abstract showError(message: string, type: MessageType): void;
   abstract showInformation(message: string, type: MessageType): void;
+  abstract setHeaderTitle(title: string, additionalInfo?: string): void;
 
   public static create(genOptions: any = {}): AppWizard {
     class EmptyAppWizard extends AppWizard {
@@ -10,6 +11,7 @@ export abstract class AppWizard {
       showWarning(): void {}
       showError(): void {}
       showInformation(): void {}
+      setHeaderTitle(title: string, additionalInfo?: string): void {}
     }
 
     return genOptions.appWizard ? genOptions.appWizard : new EmptyAppWizard();

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -11,7 +11,7 @@ export abstract class AppWizard {
       showWarning(): void {}
       showError(): void {}
       showInformation(): void {}
-      setHeaderTitle(title: string, additionalInfo?: string): void {}
+      setHeaderTitle(): void {}
     }
 
     return genOptions.appWizard ? genOptions.appWizard : new EmptyAppWizard();


### PR DESCRIPTION
provide an api to generators to update the header title and additional info on hover.

Decision was not to automatically update the title  based on the package.json as this would have overridden existing default behaviour when commands are used to launch and set the title. With an API it is entirely up to the generator when or with what information to update the title as so is a non-breaking change.