### PR TITLE
Generators prompt fix: sdk version & race condition & prompt behavior changed

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -182,7 +182,7 @@
   "dependencies": {
     "@sap-devx/webview-rpc": "0.3.1",
     "@sap-devx/yeoman-ui-types": "^1.10.7",
-    "@sap/bas-sdk": "3.2.0",
+    "@sap/bas-sdk": "3.2.1",
     "@sap/swa-for-sapbas-vsx": "1.2.7",
     "@vscode-logging/logger": "1.2.3",
     "chalk": "4.1.2",

--- a/packages/backend/src/messages.ts
+++ b/packages/backend/src/messages.ts
@@ -31,7 +31,6 @@ export default {
   add_to_workspace: "Open the project in a multi-root workspace",
   open_in_a_new_workspace: "Open the project in a stand-alone folder",
   create_and_close: "Create the project and close it for future use",
-  all_generators_have_been_installed: "All generators have been installed, enjoy your work!",
   generators_are_being_installed: "Generators are being installed in the background...",
   set_default_location: (defaultLocation: string) => `Set generators install location to ${defaultLocation}`,
   change_owner_for_global: (globalNpmPath: string) =>

--- a/packages/backend/src/utils/generators-installation-progress.ts
+++ b/packages/backend/src/utils/generators-installation-progress.ts
@@ -62,9 +62,8 @@ export async function notifyGeneratorsInstallationProgress(yeomanUIPanel: Yeoman
       // generators didn't complete installation after 5 minutes of retries..
       return window.showErrorMessage(messages.timeout_install_generators);
     }
-    if (!internal.panelDisposed) {
-      // notify ui on generators installation finished
-      yeomanUIPanel.notifyGeneratorsChange([]);
-    }
+
+    // notify ui on generators installation finished (in case of panelDisposed - will just reset the prompt message for next time)
+    yeomanUIPanel.notifyGeneratorsChange([]);
   }
 }

--- a/packages/backend/src/utils/generators-installation-progress.ts
+++ b/packages/backend/src/utils/generators-installation-progress.ts
@@ -6,7 +6,7 @@ import messages from "../messages";
 // exported for test purpose
 export const internal = {
   // MAX_RETRY(150) * DELAY_MS(2000) = 5 minutes
-  MAX_RETRY: 6,
+  MAX_RETRY: 150,
   DELAY_MS: 2000,
   retries: 0,
   panelDisposed: false,
@@ -58,8 +58,8 @@ export async function notifyGeneratorsInstallationProgress(yeomanUIPanel: Yeoman
       return window.showErrorMessage(messages.timeout_install_generators);
     }
     if (!internal.panelDisposed) {
-      // notify ui on generators installation finished
-      return yeomanUIPanel.notifyGeneratorsChange([]);
+      // reset notification on generators installation finished
+      return yeomanUIPanel["rpc"].invoke("resetPromptMessage");
     }
     // reset `panelDisposed` state for next panel loading
     internal.panelDisposed = false;

--- a/packages/backend/src/yeomanui.ts
+++ b/packages/backend/src/yeomanui.ts
@@ -116,21 +116,23 @@ export class YeomanUI {
     if (!_.isNil(args)) {
       const isGeneratorsPrompt: boolean = await this.rpc.invoke("isGeneratorsPrompt");
       if (isGeneratorsPrompt || force) {
-        this.showGeneratorsInstallingMessage(args);
+        if (_.isEmpty(args)) {
+          this.hideGeneratorsInstallingMessage();
+        } else {
+          this.showGeneratorsInstallingMessage();
+        }
       }
     }
   }
 
-  private showGeneratorsInstallingMessage(args: any[]) {
-    if (_.isEmpty(args)) {
-      this.youiEvents
-        .getAppWizard()
-        .showInformation(this.uiOptions.messages.all_generators_have_been_installed, MessageType.prompt);
-    } else {
-      this.youiEvents
-        .getAppWizard()
-        .showWarning(this.uiOptions.messages.generators_are_being_installed, MessageType.prompt);
-    }
+  private showGeneratorsInstallingMessage() {
+    this.youiEvents
+      .getAppWizard()
+      .showWarning(this.uiOptions.messages.generators_are_being_installed, MessageType.prompt);
+  }
+
+  private hideGeneratorsInstallingMessage() {
+    void this.rpc.invoke("resetPromptMessage");
   }
 
   // eslint-disable-next-line @typescript-eslint/ban-types

--- a/packages/backend/src/yeomanui.ts
+++ b/packages/backend/src/yeomanui.ts
@@ -112,13 +112,13 @@ export class YeomanUI {
   }
 
   public async _notifyGeneratorsInstall(args: any[], force: boolean) {
+    this.uiOptions.installGens = _.isObject(args) && _.isEmpty(args) ? undefined : args;
     if (!_.isNil(args)) {
       const isGeneratorsPrompt: boolean = await this.rpc.invoke("isGeneratorsPrompt");
       if (isGeneratorsPrompt || force) {
         this.showGeneratorsInstallingMessage(args);
       }
     }
-    this.uiOptions.installGens = _.isObject(args) && _.isEmpty(args) ? undefined : args;
   }
 
   private showGeneratorsInstallingMessage(args: any[]) {

--- a/packages/backend/test/yeomanui.spec.ts
+++ b/packages/backend/test/yeomanui.spec.ts
@@ -326,14 +326,13 @@ describe("yeomanui unit test", () => {
     });
     it("called with empty args array (install ended) and the prompt is generators", async () => {
       const args: any = [];
-      rpcMock.expects("invoke").withExactArgs("isGeneratorsPrompt").resolves(true);
-      youiEventsMock.expects("getAppWizard").returns(appWizard);
-      appWizardMock
-        .expects("showInformation")
-        .withExactArgs(yeomanUi["uiOptions"].messages.all_generators_have_been_installed, MessageType.prompt);
-      appWizardMock.expects("showWarning").never();
+      const rpcInvokeStub = sandbox.stub(rpc, "invoke").onFirstCall().resolves(true).onSecondCall().resolves();
       await yeomanUi._notifyGeneratorsInstall(args, false);
+      expect(rpcInvokeStub.callCount).to.equal(2);
+      expect(rpcInvokeStub.firstCall.args).to.deep.equal(["isGeneratorsPrompt"]);
+      expect(rpcInvokeStub.secondCall.args).to.deep.equal(["resetPromptMessage"]);
       expect(yeomanUi["uiOptions"].installGens).to.be.undefined;
+      rpcInvokeStub.restore();
     });
     it("called with args array containing generators (install started) and the prompt is generators", async () => {
       const args = [
@@ -407,13 +406,14 @@ describe("yeomanui unit test", () => {
   });
 
   describe("showGeneratorsInstallingMessage", () => {
-    it("called with empty args array (install ended)", () => {
-      youiEventsMock.expects("getAppWizard").returns(appWizard);
-      appWizardMock
-        .expects("showInformation")
-        .withExactArgs(yeomanUi["uiOptions"].messages.all_generators_have_been_installed, MessageType.prompt);
+    it("called with empty args array (install ended)", async () => {
+      const rpcInvokeStub = sandbox.stub(rpc, "invoke").onFirstCall().resolves(true).onSecondCall().resolves();
       appWizardMock.expects("showWarning").never();
-      yeomanUi["showGeneratorsInstallingMessage"]([]);
+      await yeomanUi._notifyGeneratorsInstall([], false);
+      expect(rpcInvokeStub.callCount).to.equal(2);
+      expect(rpcInvokeStub.firstCall.args).to.deep.equal(["isGeneratorsPrompt"]);
+      expect(rpcInvokeStub.secondCall.args).to.deep.equal(["resetPromptMessage"]);
+      rpcInvokeStub.restore();
     });
     it("called with args array containing generators (install started)", () => {
       youiEventsMock.expects("getAppWizard").returns(appWizard);
@@ -421,7 +421,7 @@ describe("yeomanui unit test", () => {
         .expects("showWarning")
         .withExactArgs(yeomanUi["uiOptions"].messages.generators_are_being_installed, MessageType.prompt);
       appWizardMock.expects("showInformation").never();
-      yeomanUi["showGeneratorsInstallingMessage"]([{}]);
+      void yeomanUi._notifyGeneratorsInstall([{}], true);
     });
   });
 

--- a/packages/frontend/src/youi/App.vue
+++ b/packages/frontend/src/youi/App.vue
@@ -78,7 +78,7 @@
             <img style="vertical-align: middle; padding-left: 12px" :src="promptMessageIcon" alt="" />
             <v-tooltip right :disabled="promptMessageToDisplay.length < this.messageMaxLength">
               <template v-slot:activator="{ on }">
-                <span :class="promptMessageClass" v-on="on">{{ showPrompt }}</span>
+                <span :class="promptMessageClass" v-on="on">{{ shortPrompt }}</span>
               </template>
               <span>{{ promptMessageToDisplay }}</span>
             </v-tooltip>
@@ -252,7 +252,7 @@ export default {
   methods: {
     showPromptMessage(message, type, image) {
       this.promptMessageToDisplay = message;
-      this.showPrompt =
+      this.shortPrompt =
         message.length < this.messageMaxLength ? message : message.substr(0, this.messageMaxLength) + "...";
       this.toShowPromptMessage = true;
       this.promptMessageIcon = image;
@@ -264,6 +264,14 @@ export default {
       } else if (type === Severity.warning) {
         this.promptMessageClass = "info-warn-prompt-message";
       }
+    },
+    resetPromptMessage() {
+      // reset prompt values to initial state
+      this.promptMessageToDisplay = "";
+      this.shortPrompt = "";
+      this.toShowPromptMessage = false;
+      this.promptMessageClass = "";
+      this.promptMessageIcon = null;
     },
     setBusyIndicator() {
       this.expectedShowBusyIndicator =
@@ -591,6 +599,7 @@ export default {
         "isGeneratorsPrompt",
         "setGenInWriting",
         "showPromptMessage",
+        "resetPromptMessage",
         "setHeaderTitle",
       ];
       _forEach(functions, (funcName) => {
@@ -658,30 +667,37 @@ export default {
 </script>
 <style scoped>
 @import "./../../node_modules/vue-loading-overlay/dist/vue-loading.css";
+
 .consoleClassVisible {
   visibility: visible;
 }
+
 .consoleClassHidden {
   visibility: hidden;
 }
+
 div.consoleClassVisible .v-footer {
   background-color: var(--vscode-editor-background, #1e1e1e);
   color: var(--vscode-foreground, #cccccc);
 }
+
 #logArea {
   font-family: monospace;
   word-wrap: break-word;
   white-space: pre-wrap;
 }
+
 .prompts-col {
   overflow-y: auto;
   margin: 0px;
   padding-bottom: 20px;
 }
+
 .main-row,
 .prompts-col {
   height: calc(100% - 4rem);
 }
+
 .left-col,
 .right-col,
 .right-row,
@@ -691,26 +707,32 @@ div.consoleClassVisible .v-footer {
 #QuestionTypeSelector > .col > div {
   height: 100%;
 }
+
 .right-col {
   padding: 0 !important;
 }
+
 .bottom-left-col {
   background: var(--vscode-editor-background, #1e1e1e);
   overflow: hidden;
   margin: 0px;
 }
+
 .bottom-buttons-col {
   padding: 12px;
   padding-right: 0px;
   margin: auto !important;
 }
+
 .bottom-buttons-col > .v-btn:not(:last-child) {
   margin-right: 10px !important;
 }
+
 .prompt-message {
   padding: 12px;
   margin: auto;
 }
+
 /* Error prompt message*/
 .error-prompt-message {
   font-size: 14px;
@@ -718,6 +740,7 @@ div.consoleClassVisible .v-footer {
   color: #ff5252;
   vertical-align: middle;
 }
+
 /* Info and Warning prompt message*/
 .info-warn-prompt-message {
   color: var(--vscode-editorCodeLens-foreground, #999999);
@@ -725,9 +748,11 @@ div.consoleClassVisible .v-footer {
   font-size: 14px;
   vertical-align: middle;
 }
+
 .v-divider {
   border-top: 2px solid var(--vscode-editorWidget-background, #252526) !important;
 }
+
 .theme--light.v-btn.v-btn--disabled:not(.v-btn--flat):not(.v-btn--text):not(.v-btn--outlined) {
   background-color: var(--vscode-descriptionForeground, #717171) !important;
 }

--- a/packages/frontend/test/App.spec.js
+++ b/packages/frontend/test/App.spec.js
@@ -964,7 +964,7 @@ describe("App.vue", () => {
       wrapper = initComponent(App);
       wrapper.vm.showPromptMessage("errorMessage", 0, "image");
       expect(wrapper.vm.promptMessageToDisplay).toEqual("errorMessage");
-      expect(wrapper.vm.showPrompt).toEqual("errorMessage");
+      expect(wrapper.vm.shortPrompt).toEqual("errorMessage");
       expect(wrapper.vm.promptMessageIcon).toEqual("image");
       expect(wrapper.vm.promptMessageClass).toEqual("error-prompt-message");
     });
@@ -973,7 +973,7 @@ describe("App.vue", () => {
       wrapper = initComponent(App);
       wrapper.vm.showPromptMessage("warnMessage", 1, "image");
       expect(wrapper.vm.promptMessageToDisplay).toEqual("warnMessage");
-      expect(wrapper.vm.showPrompt).toEqual("warnMessage");
+      expect(wrapper.vm.shortPrompt).toEqual("warnMessage");
       expect(wrapper.vm.promptMessageIcon).toEqual("image");
       expect(wrapper.vm.promptMessageClass).toEqual("info-warn-prompt-message");
     });
@@ -982,7 +982,7 @@ describe("App.vue", () => {
       wrapper = initComponent(App);
       wrapper.vm.showPromptMessage("infoMessage", 2, "image");
       expect(wrapper.vm.promptMessageToDisplay).toEqual("infoMessage");
-      expect(wrapper.vm.showPrompt).toEqual("infoMessage");
+      expect(wrapper.vm.shortPrompt).toEqual("infoMessage");
       expect(wrapper.vm.promptMessageIcon).toEqual("image");
       expect(wrapper.vm.promptMessageClass).toEqual("info-warn-prompt-message");
     });
@@ -991,7 +991,7 @@ describe("App.vue", () => {
       wrapper = initComponent(App);
       wrapper.vm.showPromptMessage("infoMessage", "neta", "image");
       expect(wrapper.vm.promptMessageToDisplay).toEqual("infoMessage");
-      expect(wrapper.vm.showPrompt).toEqual("infoMessage");
+      expect(wrapper.vm.shortPrompt).toEqual("infoMessage");
       expect(wrapper.vm.promptMessageIcon).toEqual("image");
     });
 
@@ -1000,9 +1000,28 @@ describe("App.vue", () => {
       wrapper.vm.messageMaxLength = 3;
       wrapper.vm.showPromptMessage("infoMessage", 2, "image");
       expect(wrapper.vm.promptMessageToDisplay).toEqual("infoMessage");
-      expect(wrapper.vm.showPrompt).toEqual("inf...");
+      expect(wrapper.vm.shortPrompt).toEqual("inf...");
       expect(wrapper.vm.promptMessageIcon).toEqual("image");
       expect(wrapper.vm.promptMessageClass).toEqual("info-warn-prompt-message");
+    });
+  });
+
+  describe("resetPromptMessage", () => {
+    it("should reset prompt values to initial state", () => {
+      wrapper = initComponent(App);
+      wrapper.vm.promptMessageToDisplay = "test message";
+      wrapper.vm.shortPrompt = "short message...";
+      wrapper.vm.toShowPromptMessage = true;
+      wrapper.vm.promptMessageIcon = "image";
+      wrapper.vm.promptMessageClass = "message-class";
+
+      wrapper.vm.resetPromptMessage();
+
+      expect(wrapper.vm.promptMessageToDisplay).toEqual("");
+      expect(wrapper.vm.shortPrompt).toEqual("");
+      expect(wrapper.vm.toShowPromptMessage).toEqual(false);
+      expect(wrapper.vm.promptMessageIcon).toEqual(null);
+      expect(wrapper.vm.promptMessageClass).toEqual("");
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2389,10 +2389,10 @@
   dependencies:
     ws "^7.2.3"
 
-"@sap/bas-sdk@3.2.0":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@sap/bas-sdk/-/bas-sdk-3.2.0.tgz#5e5b210b9dc60de0a7539bedc0fd076504923bc7"
-  integrity sha512-zngTwZR4BUsgHALQrVtn1yRrUTC7qlA4r+HAooxFHFWejTwm046ISBUsx8WkoWpD4+ucN4u/ReGapcTsZetMPg==
+"@sap/bas-sdk@3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@sap/bas-sdk/-/bas-sdk-3.2.1.tgz#6e43be6162a22b1a27996d9ec06118470a526c30"
+  integrity sha512-iI/JEOe8L31JmN0LnJvdC9DyxkWPYN6KHWvsASAVDiZhFiJ63aTe5ph/XcDA+lMjy8pR1rm9FHzc4dpuj2TK6A==
   dependencies:
     axios "0.21.4"
     cross-spawn "^7.0.3"


### PR DESCRIPTION
As part of moving to use the "@sap/bas-sdk" library for indicating generators installation finished - showing the message of ""All generators have been installed, enjoy your work!" will not feat anymore because the sdk api will return `true` when finished generators installation although some of generators failed to install.. so the PO decided to only show the first message of: "Generators are being installed in the background..." and when installation finished - the message will disappear and no success message... refer to  [this commit](https://github.com/SAP/yeoman-ui/pull/756/commits/2a159448907c098c30f4c2edd1e060491ab656fd)