### PR TITLE
fix(backend): do not block when nodejs install check fails

### DIFF
--- a/packages/backend/src/panels/YeomanUIPanel.ts
+++ b/packages/backend/src/panels/YeomanUIPanel.ts
@@ -42,9 +42,11 @@ export class YeomanUIPanel extends AbstractWebviewPanel {
   }
 
   public async loadWebviewPanel(uiOptions?: any): Promise<void> {
-    if (!Constants.IS_IN_BAS && (await NpmCommand.getNodeProcessVersions()).node === undefined) {
-      void vscode.window.showErrorMessage(messages.nodejs_install_not_found);
-      return;
+    if (!Constants.IS_IN_BAS) {
+      await NpmCommand.checkAccessAndSetGeneratorsPath();
+      if ((await NpmCommand.getNodeProcessVersions()).node === undefined) {
+        void vscode.window.showErrorMessage(messages.nodejs_install_not_found);
+      }
     }
     const genNamespace = uiOptions?.generator;
     if (genNamespace) {

--- a/packages/backend/src/panels/YeomanUIPanel.ts
+++ b/packages/backend/src/panels/YeomanUIPanel.ts
@@ -42,10 +42,8 @@ export class YeomanUIPanel extends AbstractWebviewPanel {
   }
 
   public async loadWebviewPanel(uiOptions?: any): Promise<void> {
-    if (!Constants.IS_IN_BAS) {
-      if ((await NpmCommand.getNodeProcessVersions()).node === undefined) {
-        void vscode.window.showErrorMessage(messages.nodejs_install_not_found);
-      }
+    if (!Constants.IS_IN_BAS && (await NpmCommand.getNodeProcessVersions()).node === undefined) {
+      void vscode.window.showErrorMessage(messages.nodejs_install_not_found);
     }
     const genNamespace = uiOptions?.generator;
     if (genNamespace) {

--- a/packages/backend/src/panels/YeomanUIPanel.ts
+++ b/packages/backend/src/panels/YeomanUIPanel.ts
@@ -43,7 +43,6 @@ export class YeomanUIPanel extends AbstractWebviewPanel {
 
   public async loadWebviewPanel(uiOptions?: any): Promise<void> {
     if (!Constants.IS_IN_BAS) {
-      await NpmCommand.checkAccessAndSetGeneratorsPath();
       if ((await NpmCommand.getNodeProcessVersions()).node === undefined) {
         void vscode.window.showErrorMessage(messages.nodejs_install_not_found);
       }

--- a/packages/backend/test/panels/YeomanUIPanel.spec.ts
+++ b/packages/backend/test/panels/YeomanUIPanel.spec.ts
@@ -61,6 +61,7 @@ describe("YeomanUIPanel unit test", () => {
     });
 
     it("generator is choosen", () => {
+      npmUtilsMock.expects("checkAccessAndSetGeneratorsPath").resolves();
       npmUtilsMock.expects("getNodeProcessVersions").resolves({ node: "20.6.0" });
       envUtilsMock.expects("getAllGeneratorNamespaces").twice().resolves(["gen1:test", "test:app", "code:app"]);
       windowMock.expects("showQuickPick").resolves("test:app");
@@ -71,6 +72,7 @@ describe("YeomanUIPanel unit test", () => {
   describe("loadWebviewPanel", () => {
     describe("in VSCODE", () => {
       beforeEach(() => {
+        npmUtilsMock.expects("checkAccessAndSetGeneratorsPath").resolves();
         npmUtilsMock.expects("getNodeProcessVersions").resolves({ node: "20.6.0" });
         Constants["IS_IN_BAS"] = false;
       });
@@ -140,9 +142,10 @@ describe("YeomanUIPanel unit test", () => {
         Constants["IS_IN_BAS"] = false;
       });
 
-      it("should show an error message", async () => {
+      it("should show an error message", () => {
+        npmUtilsMock.expects("checkAccessAndSetGeneratorsPath");
         windowMock.expects("showErrorMessage").withExactArgs(messages.nodejs_install_not_found);
-        await panel.loadWebviewPanel();
+        void panel.loadWebviewPanel();
       });
     });
   });

--- a/packages/backend/test/panels/YeomanUIPanel.spec.ts
+++ b/packages/backend/test/panels/YeomanUIPanel.spec.ts
@@ -61,7 +61,6 @@ describe("YeomanUIPanel unit test", () => {
     });
 
     it("generator is choosen", () => {
-      npmUtilsMock.expects("checkAccessAndSetGeneratorsPath").resolves();
       npmUtilsMock.expects("getNodeProcessVersions").resolves({ node: "20.6.0" });
       envUtilsMock.expects("getAllGeneratorNamespaces").twice().resolves(["gen1:test", "test:app", "code:app"]);
       windowMock.expects("showQuickPick").resolves("test:app");
@@ -72,7 +71,6 @@ describe("YeomanUIPanel unit test", () => {
   describe("loadWebviewPanel", () => {
     describe("in VSCODE", () => {
       beforeEach(() => {
-        npmUtilsMock.expects("checkAccessAndSetGeneratorsPath").resolves();
         npmUtilsMock.expects("getNodeProcessVersions").resolves({ node: "20.6.0" });
         Constants["IS_IN_BAS"] = false;
       });
@@ -143,7 +141,6 @@ describe("YeomanUIPanel unit test", () => {
       });
 
       it("should show an error message", () => {
-        npmUtilsMock.expects("checkAccessAndSetGeneratorsPath");
         windowMock.expects("showErrorMessage").withExactArgs(messages.nodejs_install_not_found);
         void panel.loadWebviewPanel();
       });


### PR DESCRIPTION
https://github.com/SAP/yeoman-ui/issues/780
https://github.com/SAP/yeoman-ui/pull/779

- during the check for NodeJS installation, if none is found it should not block the wizard/panel from opening (keep existing flow the same)
