### PR TITLE
feature: remove show done message if no files are generated

### DIFF
--- a/packages/backend/src/yeomanui.ts
+++ b/packages/backend/src/yeomanui.ts
@@ -414,7 +414,7 @@ export class YeomanUI {
     // All the paths here absolute normilized paths.
     const targetFolderPathBeforeGen: string = _.get(resourcesBeforeGen, "targetFolderPath");
     const targetFolderPathAfterGen: string = _.get(resourcesAfterGen, "targetFolderPath");
-    const generatedChildDirs = "generatedChildDirs";
+    let hasNewDirs: boolean = true;
     if (targetFolderPathBeforeGen === targetFolderPathAfterGen) {
       const newDirs: string[] = _.difference(
         _.get(resourcesAfterGen, "childDirs"),
@@ -424,8 +424,8 @@ export class YeomanUI {
         // One folder added by generator and targetFolderPath/destinationRoot was not changed by generator.
         // ---> Fiori project generator flow.
         targetFolderPath = newDirs[0];
-      } else if (_.size(newDirs) > 1) {
-        targetFolderPath = generatedChildDirs;
+      } else if (_.size(newDirs) === 0) {
+        hasNewDirs = false;
       }
       //else { //_.size(newDirs) = 0 (0 folders) or _.size(newDirs) > 1 (5 folders)
       // We don't know what is the correct targetFolderPath ---> no buttons should be shown.
@@ -453,10 +453,8 @@ export class YeomanUI {
     AnalyticsWrapper.updateGeneratorEnded(generatorName);
     // Checking if targetFolderPath is null or undefined to determine toast message.
     // if no files are generated (undefined), messsage is empty
-    if (_.isNil(targetFolderPath)) {
+    if (!targetFolderPath && !hasNewDirs) {
       this.youiEvents.doGeneratorDone(false, "", selectedWorkspace, type, targetFolderPath);
-    } else if (targetFolderPath === generatedChildDirs) {
-      this.youiEvents.doGeneratorDone(true, message, selectedWorkspace, type, null);
     } else {
       this.youiEvents.doGeneratorDone(true, message, selectedWorkspace, type, targetFolderPath);
     }

--- a/packages/backend/src/yeomanui.ts
+++ b/packages/backend/src/yeomanui.ts
@@ -414,6 +414,7 @@ export class YeomanUI {
     // All the paths here absolute normilized paths.
     const targetFolderPathBeforeGen: string = _.get(resourcesBeforeGen, "targetFolderPath");
     const targetFolderPathAfterGen: string = _.get(resourcesAfterGen, "targetFolderPath");
+    const generatedChildDirs = "generatedChildDirs";
     if (targetFolderPathBeforeGen === targetFolderPathAfterGen) {
       const newDirs: string[] = _.difference(
         _.get(resourcesAfterGen, "childDirs"),
@@ -423,7 +424,10 @@ export class YeomanUI {
         // One folder added by generator and targetFolderPath/destinationRoot was not changed by generator.
         // ---> Fiori project generator flow.
         targetFolderPath = newDirs[0];
-      } //else { //_.size(newDirs) = 0 (0 folders) or _.size(newDirs) > 1 (5 folders)
+      } else if (_.size(newDirs) > 1) {
+        targetFolderPath = generatedChildDirs;
+      }
+      //else { //_.size(newDirs) = 0 (0 folders) or _.size(newDirs) > 1 (5 folders)
       // We don't know what is the correct targetFolderPath ---> no buttons should be shown.
       // No folder added by generator ---> Fiori module generator flow.
       // Many folders added by generator --->
@@ -447,7 +451,13 @@ export class YeomanUI {
     const generatedTemplatePath = targetFolderPath ? targetFolderPath : targetFolderPathBeforeGen;
     this.logger.debug(`done running yeomanui! ${message} You can find it at ${generatedTemplatePath}`);
     AnalyticsWrapper.updateGeneratorEnded(generatorName);
-    this.youiEvents.doGeneratorDone(true, message, selectedWorkspace, type, targetFolderPath);
+    // Checking if targetFolderPath is null or undefined to determine toast message.
+    // if no files are generated (undefined), messsage is empty
+    if (_.isNil(targetFolderPath)) {
+      this.youiEvents.doGeneratorDone(false, "", selectedWorkspace, type, targetFolderPath);
+    } else {
+      this.youiEvents.doGeneratorDone(true, message, selectedWorkspace, type, targetFolderPath);
+    }
     this.setInitialProcessDir();
     this.flowState.resolve();
     this.generatorName = ""; // reset generator name

--- a/packages/backend/src/yeomanui.ts
+++ b/packages/backend/src/yeomanui.ts
@@ -455,6 +455,8 @@ export class YeomanUI {
     // if no files are generated (undefined), messsage is empty
     if (_.isNil(targetFolderPath)) {
       this.youiEvents.doGeneratorDone(false, "", selectedWorkspace, type, targetFolderPath);
+    } else if (targetFolderPath === generatedChildDirs) {
+      this.youiEvents.doGeneratorDone(true, message, selectedWorkspace, type, null);
     } else {
       this.youiEvents.doGeneratorDone(true, message, selectedWorkspace, type, targetFolderPath);
     }

--- a/packages/backend/test/yeomanui.spec.ts
+++ b/packages/backend/test/yeomanui.spec.ts
@@ -1157,7 +1157,7 @@ describe("yeomanui unit test", () => {
           _.get(yeomanUi, "uiOptions.messages.artifact_with_name_generated", (a: string) => "")("testGenName"),
           create_and_close,
           "files",
-          "generatedChildDirs",
+          null,
         ),
       ).to.be.true;
     });

--- a/packages/backend/test/yeomanui.spec.ts
+++ b/packages/backend/test/yeomanui.spec.ts
@@ -1157,7 +1157,7 @@ describe("yeomanui unit test", () => {
           _.get(yeomanUi, "uiOptions.messages.artifact_with_name_generated", (a: string) => "")("testGenName"),
           create_and_close,
           "files",
-          null,
+          "generatedChildDirs",
         ),
       ).to.be.true;
     });
@@ -1175,9 +1175,9 @@ describe("yeomanui unit test", () => {
       yeomanUi["onGeneratorSuccess"]("testGenName", beforeGen, afterGen);
       expect(
         doGeneratorDoneSpy.calledWith(
-          true,
+          false,
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          _.get(yeomanUi, "uiOptions.messages.artifact_with_name_generated", (a: string) => "")("testGenName"),
+          "",
           create_and_close,
           "files",
           null,


### PR DESCRIPTION
Implements: #844 

- Additional logic to check if no files generated and targetPath is null,
   - `doGeneratorDone` empty string passed for message. No pop-up.