### PR TITLE
fix: remove show done message if no files are generated

### DIFF
--- a/packages/backend/src/vscode-youi-events.ts
+++ b/packages/backend/src/vscode-youi-events.ts
@@ -193,7 +193,9 @@ export class VSCodeYouiEvents implements YouiEvents {
       }
 
       const successInfoMessage = this.getSuccessInfoMessage(selectedWorkspace, type);
-      return vscode.window.showInformationMessage(successInfoMessage);
+      return successInfoMessage // show the message only if it is not empty
+        ? vscode.window.showInformationMessage(successInfoMessage)
+        : Promise.resolve();
     }
 
     return vscode.window.showErrorMessage(errorMmessage);
@@ -211,6 +213,8 @@ export class VSCodeYouiEvents implements YouiEvents {
       }
     } else if (type === "module") {
       successInfoMessage = this.messages.artifact_generated_module;
+    } else if (type === "") {
+      successInfoMessage = ""; // do not show information message
     }
     return successInfoMessage;
   }

--- a/packages/backend/src/yeomanui.ts
+++ b/packages/backend/src/yeomanui.ts
@@ -414,6 +414,7 @@ export class YeomanUI {
     // All the paths here absolute normilized paths.
     const targetFolderPathBeforeGen: string = _.get(resourcesBeforeGen, "targetFolderPath");
     const targetFolderPathAfterGen: string = _.get(resourcesAfterGen, "targetFolderPath");
+    let hasNewDirs: boolean = true;
     if (targetFolderPathBeforeGen === targetFolderPathAfterGen) {
       const newDirs: string[] = _.difference(
         _.get(resourcesAfterGen, "childDirs"),
@@ -423,7 +424,10 @@ export class YeomanUI {
         // One folder added by generator and targetFolderPath/destinationRoot was not changed by generator.
         // ---> Fiori project generator flow.
         targetFolderPath = newDirs[0];
-      } //else { //_.size(newDirs) = 0 (0 folders) or _.size(newDirs) > 1 (5 folders)
+      } else if (_.size(newDirs) === 0) {
+        hasNewDirs = false;
+      }
+      //else { // _.size(newDirs) > 1 (5 folders)
       // We don't know what is the correct targetFolderPath ---> no buttons should be shown.
       // No folder added by generator ---> Fiori module generator flow.
       // Many folders added by generator --->
@@ -447,7 +451,8 @@ export class YeomanUI {
     const generatedTemplatePath = targetFolderPath ? targetFolderPath : targetFolderPathBeforeGen;
     this.logger.debug(`done running yeomanui! ${message} You can find it at ${generatedTemplatePath}`);
     AnalyticsWrapper.updateGeneratorEnded(generatorName);
-    this.youiEvents.doGeneratorDone(true, message, selectedWorkspace, type, targetFolderPath);
+    // when targetFolderPath is undefined and no files are generated, send type = '' to get the empty toast message
+    this.youiEvents.doGeneratorDone(true, message, selectedWorkspace, hasNewDirs ? type : "", targetFolderPath);
     this.setInitialProcessDir();
     this.flowState.resolve();
     this.generatorName = ""; // reset generator name

--- a/packages/backend/test/yeomanui.spec.ts
+++ b/packages/backend/test/yeomanui.spec.ts
@@ -1179,7 +1179,7 @@ describe("yeomanui unit test", () => {
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
           _.get(yeomanUi, "uiOptions.messages.artifact_with_name_generated", (a: string) => "")("testGenName"),
           create_and_close,
-          "files",
+          "",
           null,
         ),
       ).to.be.true;


### PR DESCRIPTION
Implements: https://github.com/SAP/yeoman-ui/issues/844

Additional logic to check if no files generated and targetPath is null,
doGeneratorDone empty string passed for message. No pop-up.