### PR TITLE
fix(extension) quick fix for vscode 1.94.x compatibility due to switch to ESM modules

### DIFF
--- a/packages/backend/src/utils/vscodeProxy.ts
+++ b/packages/backend/src/utils/vscodeProxy.ts
@@ -10,8 +10,8 @@ export const getVscode = () => {
   }
 };
 
-const filename: string = require.main.filename;
-const _isInTest = filename.includes(join("node_modules", "mocha"));
+const filename: string = require?.main?.filename;
+const _isInTest = filename?.includes(join("node_modules", "mocha"));
 
 const returnValue = (...args: any[]) => {
   if (_isInTest) {


### PR DESCRIPTION
Fix error opening Application Wizard in VS Code 1.94.x+ 
![image](https://github.com/user-attachments/assets/0a15fdff-346c-411c-b26b-55462d36ad03)

Due to VSCode changing to ESM modules in this release https://code.visualstudio.com/updates/v1_93#_impact-of-ecmascript-module-esm-loading-of-vs-code `require.main` is now undefined. 