### PR TITLE
feat: Configuration for sub generators tiles in Template Wizard

### DIFF
--- a/packages/backend/src/utils/env.ts
+++ b/packages/backend/src/utils/env.ts
@@ -34,7 +34,7 @@ export type AdditionalGenerator = {
   description: string;
   homePage?: string;
   image?: string;
-}
+};
 
 export class GeneratorNotFoundError extends Error {
   constructor(message: string) {
@@ -150,18 +150,21 @@ class EnvUtil {
     mainGenerators.forEach((genMeta) => {
       try {
         const packageJsonPath = join(genMeta.packagePath, PACKAGE_JSON);
-        const { additional_generators }: { additional_generators: AdditionalGenerator[] } = JSON.parse(readFileSync(packageJsonPath, "utf-8"));
-        if (additional_generators?.length)
-          additionalGenerators = [...additional_generators];
+        const { additional_generators }: { additional_generators: AdditionalGenerator[] } = JSON.parse(
+          readFileSync(packageJsonPath, "utf-8"),
+        );
+        if (additional_generators?.length) additionalGenerators = [...additional_generators];
       } catch (error) {
-        this.logger?.debug('Error occured while trying to get additional generator tiles', error);
+        this.logger?.debug("Error occured while trying to get additional generator tiles", error);
       }
     });
 
-    const additionalGeneratorsMeta = gensMeta.filter((genMeta) => additionalGenerators.find((gen) => gen.namespace === genMeta.namespace)).map((genMeta: LookupGeneratorMetaExtended) => {
-      genMeta.isAdditional = true;
-      return genMeta;
-    });
+    const additionalGeneratorsMeta = gensMeta
+      .filter((genMeta) => additionalGenerators.find((gen) => gen.namespace === genMeta.namespace))
+      .map((genMeta: LookupGeneratorMetaExtended) => {
+        genMeta.isAdditional = true;
+        return genMeta;
+      });
 
     return mainGenerators.concat(additionalGeneratorsMeta);
   }

--- a/packages/backend/src/utils/env.ts
+++ b/packages/backend/src/utils/env.ts
@@ -1,26 +1,40 @@
 import * as _ from "lodash";
 import { homedir } from "os";
 import * as path from "path";
-import { existsSync } from "fs";
+import { existsSync, readFileSync } from "fs";
 import { isWin32, NpmCommand } from "./npm";
 import * as customLocation from "./customLocation";
 import * as Environment from "yeoman-environment";
 import TerminalAdapter = require("yeoman-environment/lib/adapter");
 import { IChildLogger } from "@vscode-logging/logger";
 import { getClassLogger } from "../logger/logger-wrapper";
+import { join } from "path";
 
 const GENERATOR = "generator-";
 const NAMESPACE = "namespace";
+const PACKAGE_JSON = "package.json";
 
 export type EnvGen = {
   env: Environment<Environment.Options>;
   gen: any;
 };
 
+interface LookupGeneratorMetaExtended extends Environment.LookupGeneratorMeta {
+  isAdditional?: boolean;
+}
+
 export type GeneratorData = {
-  generatorMeta: Environment.LookupGeneratorMeta;
+  generatorMeta: LookupGeneratorMetaExtended;
   generatorPackageJson: any;
 };
+
+export type AdditionalGenerator = {
+  namespace: string;
+  displayName: string;
+  description: string;
+  homePage?: string;
+  image?: string;
+}
 
 export class GeneratorNotFoundError extends Error {
   constructor(message: string) {
@@ -130,8 +144,26 @@ class EnvUtil {
     throw new GeneratorNotFoundError(`${genNamespace} generator metadata was not found.`);
   }
 
-  private genMainGensMeta(gensMeta: Environment.LookupGeneratorMeta[]): Environment.LookupGeneratorMeta[] {
-    return gensMeta.filter((genMeta) => genMeta.namespace.endsWith(":app"));
+  private genMainGensMeta(gensMeta: Environment.LookupGeneratorMeta[]): LookupGeneratorMetaExtended[] {
+    const mainGenerators = gensMeta.filter((genMeta) => genMeta.namespace.endsWith(":app"));
+    let additionalGenerators: AdditionalGenerator[] = [];
+    mainGenerators.forEach((genMeta) => {
+      try {
+        const packageJsonPath = join(genMeta.packagePath, PACKAGE_JSON);
+        const { additional_generators }: { additional_generators: AdditionalGenerator[] } = JSON.parse(readFileSync(packageJsonPath, "utf-8"));
+        if (additional_generators?.length)
+          additionalGenerators = [...additional_generators];
+      } catch (error) {
+        this.logger?.debug('Error occured while trying to get additional generator tiles', error);
+      }
+    });
+
+    const additionalGeneratorsMeta = gensMeta.filter((genMeta) => additionalGenerators.find((gen) => gen.namespace === genMeta.namespace)).map((genMeta: LookupGeneratorMetaExtended) => {
+      genMeta.isAdditional = true;
+      return genMeta;
+    });
+
+    return mainGenerators.concat(additionalGeneratorsMeta);
   }
 
   private async getGensMetaByInstallationPath(): Promise<Environment.LookupGeneratorMeta[]> {
@@ -139,7 +171,7 @@ class EnvUtil {
     return this.lookupGensMeta({ npmPaths: npmInstallationPaths });
   }
 
-  private async getGeneratorsMeta(mainOnly = true): Promise<Environment.LookupGeneratorMeta[]> {
+  private async getGeneratorsMeta(mainOnly = true): Promise<LookupGeneratorMetaExtended[]> {
     this.allInstalledGensMeta = await this.lookupAllGensMeta();
     return mainOnly ? this.genMainGensMeta(this.allInstalledGensMeta) : this.allInstalledGensMeta;
   }
@@ -164,7 +196,7 @@ class EnvUtil {
   }
 
   public async getGeneratorsData(mainOnly = true): Promise<GeneratorData[]> {
-    const gensMeta: Environment.LookupGeneratorMeta[] = await this.getGeneratorsMeta(mainOnly);
+    const gensMeta: LookupGeneratorMetaExtended[] = await this.getGeneratorsMeta(mainOnly);
     const packageJsons = await NpmCommand.getPackageJsons(gensMeta);
 
     const gensData = packageJsons.map((generatorPackageJson: any | undefined, index: number) => {

--- a/packages/backend/src/yeomanui.ts
+++ b/packages/backend/src/yeomanui.ts
@@ -16,7 +16,7 @@ import { IPrompt, MessageType } from "@sap-devx/yeoman-ui-types";
 import { AnalyticsWrapper } from "./usage-report/usage-analytics-wrapper";
 import { Output } from "./output";
 import { resolve } from "path";
-import { Env, EnvGen, GeneratorData, GeneratorNotFoundError } from "./utils/env";
+import { AdditionalGenerator, Env, EnvGen, GeneratorData, GeneratorNotFoundError } from "./utils/env";
 import { vscode, getVscode } from "./utils/vscodeProxy";
 import * as Generator from "yeoman-generator";
 import * as Environment from "yeoman-environment";
@@ -592,6 +592,7 @@ export class YeomanUI {
   private async getGeneratorChoice(genData: GeneratorData, filter: GeneratorFilter, hiddenGeneratorsArray: string[]) {
     const packageJson = genData.generatorPackageJson;
     const genMeta = genData.generatorMeta;
+    const isAdditionalGenerator = genMeta.isAdditional;
     const genFilter: GeneratorFilter = GeneratorFilter.create(_.get(packageJson, ["generator-filter"]));
     const typesHasIntersection: boolean = GeneratorFilter.hasIntersection(filter.types, genFilter.types);
     const categoriesHasIntersection: boolean = GeneratorFilter.hasIntersection(filter.categories, genFilter.categories);
@@ -608,25 +609,43 @@ export class YeomanUI {
       hidden = true;
     }
     if (!hidden && typesHasIntersection && categoriesHasIntersection) {
-      return this.createGeneratorChoice(genMeta.namespace, genMeta.packagePath, packageJson);
+      return this.createGeneratorChoice(genMeta.namespace, genMeta.packagePath, packageJson, isAdditionalGenerator);
     }
   }
 
-  private async createGeneratorChoice(genNamespace: string, genPackagePath: string, packageJson: any): Promise<any> {
+  private async getGeneratorImageUrl(genPackagePath: string, image?: string): Promise<any> {
     let genImageUrl;
-
     try {
-      genImageUrl = await datauri(path.join(genPackagePath, YeomanUI.YEOMAN_PNG));
+      genImageUrl = await datauri(path.join(genPackagePath, image));
     } catch (error) {
       genImageUrl = defaultImage.default;
       this.logger.debug(error);
     }
 
+    return genImageUrl;
+  }
+
+  private async createGeneratorChoice(genNamespace: string, genPackagePath: string, packageJson: any, isAdditionalGenerator?: boolean): Promise<any> {
+    let genImageUrl = await this.getGeneratorImageUrl(genPackagePath, YeomanUI.YEOMAN_PNG);
+    let genMessage = _.get(packageJson, "description", YeomanUI.defaultMessage);
+    let genDisplayName = _.get(packageJson, "displayName", "");
+    let genHomepage = _.get(packageJson, "homepage", "");
+
+    if (isAdditionalGenerator) {
+      const additionalGenerators = _.get(packageJson, "additional_generators");
+      if (additionalGenerators) {
+        const genData: AdditionalGenerator = additionalGenerators.find((gen: AdditionalGenerator) => gen.namespace === genNamespace);
+        genMessage = genData.description;
+        genDisplayName = genData.displayName;
+        genHomepage = genData?.homePage ?? genHomepage;
+        genImageUrl = await this.getGeneratorImageUrl(genPackagePath, genData.image);
+      }
+    }
+
     const genName = Environment.namespaceToName(genNamespace);
-    const genMessage = _.get(packageJson, "description", YeomanUI.defaultMessage);
-    const genDisplayName = _.get(packageJson, "displayName", "");
+
     const genPrettyName = _.isEmpty(genDisplayName) ? titleize(humanizeString(genName)) : genDisplayName;
-    const genHomepage = _.get(packageJson, "homepage", "");
+    
     const filter = _.get(packageJson, "generator-filter", undefined);
     const isToolsSuiteType = filter ? _.includes(filter.types, "tools-suite") : false;
 

--- a/packages/backend/src/yeomanui.ts
+++ b/packages/backend/src/yeomanui.ts
@@ -625,7 +625,12 @@ export class YeomanUI {
     return genImageUrl;
   }
 
-  private async createGeneratorChoice(genNamespace: string, genPackagePath: string, packageJson: any, isAdditionalGenerator?: boolean): Promise<any> {
+  private async createGeneratorChoice(
+    genNamespace: string,
+    genPackagePath: string,
+    packageJson: any,
+    isAdditionalGenerator?: boolean,
+  ): Promise<any> {
     let genImageUrl = await this.getGeneratorImageUrl(genPackagePath, YeomanUI.YEOMAN_PNG);
     let genMessage = _.get(packageJson, "description", YeomanUI.defaultMessage);
     let genDisplayName = _.get(packageJson, "displayName", "");
@@ -634,7 +639,9 @@ export class YeomanUI {
     if (isAdditionalGenerator) {
       const additionalGenerators = _.get(packageJson, "additional_generators");
       if (additionalGenerators) {
-        const genData: AdditionalGenerator = additionalGenerators.find((gen: AdditionalGenerator) => gen.namespace === genNamespace);
+        const genData: AdditionalGenerator = additionalGenerators.find(
+          (gen: AdditionalGenerator) => gen.namespace === genNamespace,
+        );
         genMessage = genData.description;
         genDisplayName = genData.displayName;
         genHomepage = genData?.homePage ?? genHomepage;
@@ -645,7 +652,7 @@ export class YeomanUI {
     const genName = Environment.namespaceToName(genNamespace);
 
     const genPrettyName = _.isEmpty(genDisplayName) ? titleize(humanizeString(genName)) : genDisplayName;
-    
+
     const filter = _.get(packageJson, "generator-filter", undefined);
     const isToolsSuiteType = filter ? _.includes(filter.types, "tools-suite") : false;
 

--- a/packages/backend/test/yeomanui.spec.ts
+++ b/packages/backend/test/yeomanui.spec.ts
@@ -8,11 +8,7 @@ import * as _ from "lodash";
 import { YeomanUI } from "../src/yeomanui";
 import { ReplayUtils } from "../src/replayUtils";
 import { YouiEvents } from "../src/youi-events";
-import {
-  IMethod,
-  IPromiseCallbacks,
-  IRpc,
-} from "@sap-devx/webview-rpc/out.ext/rpc-common";
+import { IMethod, IPromiseCallbacks, IRpc } from "@sap-devx/webview-rpc/out.ext/rpc-common";
 import { GeneratorFilter } from "../src/filter";
 import messages from "../src/messages";
 import { AnalyticsWrapper } from "../src/usage-report/usage-analytics-wrapper";
@@ -138,7 +134,7 @@ describe("yeomanui unit test", () => {
     outputChannel,
     testLogger,
     { filter: GeneratorFilter.create(), messages },
-    flowPromise.state
+    flowPromise.state,
   );
 
   before(() => {
@@ -184,16 +180,12 @@ describe("yeomanui unit test", () => {
 
     beforeEach(() => {
       stubStat = sandbox.stub(fs, "statSync");
-      sandbox
-        .stub(fs, "watch")
-        .value(
-          (p: string, o: any, cb: (event: string, file: string) => void) => {
-            callBack = cb;
-            return {
-              close: () => { },
-            };
-          }
-        );
+      sandbox.stub(fs, "watch").value((p: string, o: any, cb: (event: string, file: string) => void) => {
+        callBack = cb;
+        return {
+          close: () => {},
+        };
+      });
     });
 
     afterEach(() => {
@@ -205,15 +197,9 @@ describe("yeomanui unit test", () => {
       const folderPath = path.join("testPath");
       const subFolderPath = path.join(folderPath, "subFolderPath");
       const filePath = path.join(subFolderPath, "file1");
-      stubStat
-        .withArgs(path.join(targetPath, folderPath))
-        .returns({ isDirectory: () => true });
-      stubStat
-        .withArgs(path.join(targetPath, subFolderPath))
-        .returns({ isDirectory: () => true });
-      stubStat
-        .withArgs(path.join(targetPath, filePath))
-        .returns({ isDirectory: () => false, size: 100, mtime: 1233 });
+      stubStat.withArgs(path.join(targetPath, folderPath)).returns({ isDirectory: () => true });
+      stubStat.withArgs(path.join(targetPath, subFolderPath)).returns({ isDirectory: () => true });
+      stubStat.withArgs(path.join(targetPath, filePath)).returns({ isDirectory: () => false, size: 100, mtime: 1233 });
       expect(yeomanUi["startWatch"](targetPath, targetMap)).to.not.empty;
       callBack("rename", folderPath);
       callBack("rename", subFolderPath);
@@ -229,9 +215,7 @@ describe("yeomanui unit test", () => {
     it("startWatch, 'change' event skipped", () => {
       const targetPath = path.join("/", "targetRoot");
       const folderPath = path.join("testPath");
-      stubStat
-        .withArgs(path.join(targetPath, folderPath))
-        .returns({ isDirectory: () => true });
+      stubStat.withArgs(path.join(targetPath, folderPath)).returns({ isDirectory: () => true });
       expect(yeomanUi["startWatch"](targetPath, targetMap)).to.not.empty;
       callBack("change", folderPath);
       expect(targetMap.size).to.equal(0);
@@ -240,9 +224,7 @@ describe("yeomanui unit test", () => {
     it("startWatch, 'statSync' throws exception", () => {
       const targetPath = path.join("/", "targetRoot");
       const folderPath = path.join("testPath");
-      stubStat
-        .withArgs(path.join(targetPath, folderPath))
-        .throws("statSync error");
+      stubStat.withArgs(path.join(targetPath, folderPath)).throws("statSync error");
       expect(yeomanUi["startWatch"](targetPath, targetMap)).to.not.empty;
       callBack("rename", folderPath);
       expect(targetMap.size).to.equal(0);
@@ -302,15 +284,11 @@ describe("yeomanui unit test", () => {
 
     beforeEach(() => {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      sandbox
-        .stub(fs, "watch")
-        .value(
-          (p: string, o: any, cb: (event: string, file: string) => void) => {
-            return {
-              close: () => { },
-            };
-          }
-        );
+      sandbox.stub(fs, "watch").value((p: string, o: any, cb: (event: string, file: string) => void) => {
+        return {
+          close: () => {},
+        };
+      });
     });
 
     it("flow is successfull", async () => {
@@ -329,35 +307,13 @@ describe("yeomanui unit test", () => {
           },
         });
       youiEventsMock.expects("setAppWizardHeaderTitle").withArgs(undefined);
-      wsConfigMock
-        .expects("get")
-        .withExactArgs("ApplicationWizard.TargetFolder")
-        .twice();
-      wsConfigMock
-        .expects("get")
-        .withExactArgs("ApplicationWizard.HideGenerator")
-        .once()
-        .returns("");
-      rpcMock
-        .expects("invoke")
-        .withArgs("showPrompt")
-        .resolves({ generator: "test1-project:app" });
-      rpcMock
-        .expects("invoke")
-        .withExactArgs("setGenInWriting", [false])
-        .resolves();
-      trackerWrapperMock
-        .expects("updateGeneratorStarted")
-        .once()
-        .returns(undefined);
-      trackerWrapperMock
-        .expects("updateGeneratorSelected")
-        .withArgs("test1-project:app")
-        .returns(undefined);
-      trackerWrapperMock
-        .expects("updateGeneratorEnded")
-        .once()
-        .returns(undefined);
+      wsConfigMock.expects("get").withExactArgs("ApplicationWizard.TargetFolder").twice();
+      wsConfigMock.expects("get").withExactArgs("ApplicationWizard.HideGenerator").once().returns("");
+      rpcMock.expects("invoke").withArgs("showPrompt").resolves({ generator: "test1-project:app" });
+      rpcMock.expects("invoke").withExactArgs("setGenInWriting", [false]).resolves();
+      trackerWrapperMock.expects("updateGeneratorStarted").once().returns(undefined);
+      trackerWrapperMock.expects("updateGeneratorSelected").withArgs("test1-project:app").returns(undefined);
+      trackerWrapperMock.expects("updateGeneratorEnded").once().returns(undefined);
       await yeomanUi["receiveIsWebviewReady"]();
     });
 
@@ -383,18 +339,9 @@ describe("yeomanui unit test", () => {
             on: () => "",
           },
         });
-      wsConfigMock
-        .expects("get")
-        .withExactArgs(yeomanUi["TARGET_FOLDER_CONFIG_PROP"])
-        .twice();
-      rpcMock
-        .expects("invoke")
-        .withExactArgs("setGenInWriting", [false])
-        .resolves();
-      trackerWrapperMock
-        .expects("updateGeneratorSelected")
-        .withArgs("test4:app")
-        .resolves();
+      wsConfigMock.expects("get").withExactArgs(yeomanUi["TARGET_FOLDER_CONFIG_PROP"]).twice();
+      rpcMock.expects("invoke").withExactArgs("setGenInWriting", [false]).resolves();
+      trackerWrapperMock.expects("updateGeneratorSelected").withArgs("test4:app").resolves();
       trackerWrapperMock.expects("updateGeneratorEnded").once().resolves();
       await yeomanUi["receiveIsWebviewReady"]();
     });
@@ -409,9 +356,7 @@ describe("yeomanui unit test", () => {
     it("called with command id & args", () => {
       const commandId = "vscode.open";
       const commandArgs = [{ fsPath: "https://en.wikipedia.org" }];
-      youiEventsMock
-        .expects("executeCommand")
-        .withExactArgs(commandId, commandArgs);
+      youiEventsMock.expects("executeCommand").withExactArgs(commandId, commandArgs);
       yeomanUi["executeCommand"](commandId, ...commandArgs);
     });
   });
@@ -436,19 +381,13 @@ describe("yeomanui unit test", () => {
 
   it("_notifyGeneratorsChange", async () => {
     envUtilsMock.expects("getGeneratorsData").resolves();
-    wsConfigMock
-      .expects("get")
-      .withExactArgs("ApplicationWizard.HideGenerator")
-      .returns("");
+    wsConfigMock.expects("get").withExactArgs("ApplicationWizard.HideGenerator").returns("");
     rpcMock.expects("invoke").withArgs("updateGeneratorsPrompt");
     await yeomanUi._notifyGeneratorsChange();
   });
 
   it("running generator throws error and watcher does not exist", async () => {
-    wsConfigMock
-      .expects("get")
-      .withExactArgs("ApplicationWizard.TargetFolder")
-      .throws("get error");
+    wsConfigMock.expects("get").withExactArgs("ApplicationWizard.TargetFolder").throws("get error");
     sandbox.stub(yeomanUi as any, "onGeneratorFailure").returns({});
     await yeomanUi["runGenerator"]("test1-project:app");
   });
@@ -461,20 +400,11 @@ describe("yeomanui unit test", () => {
     });
     it("called with empty args array (install ended) and the prompt is generators", async () => {
       const args: any = [];
-      const rpcInvokeStub = sandbox
-        .stub(rpc, "invoke")
-        .onFirstCall()
-        .resolves(true)
-        .onSecondCall()
-        .resolves();
+      const rpcInvokeStub = sandbox.stub(rpc, "invoke").onFirstCall().resolves(true).onSecondCall().resolves();
       await yeomanUi._notifyGeneratorsInstall(args, false);
       expect(rpcInvokeStub.callCount).to.equal(2);
-      expect(rpcInvokeStub.firstCall.args).to.deep.equal([
-        "isGeneratorsPrompt",
-      ]);
-      expect(rpcInvokeStub.secondCall.args).to.deep.equal([
-        "resetPromptMessage",
-      ]);
+      expect(rpcInvokeStub.firstCall.args).to.deep.equal(["isGeneratorsPrompt"]);
+      expect(rpcInvokeStub.secondCall.args).to.deep.equal(["resetPromptMessage"]);
       expect(yeomanUi["uiOptions"].installGens).to.be.undefined;
       rpcInvokeStub.restore();
     });
@@ -493,17 +423,11 @@ describe("yeomanui unit test", () => {
           versionRange: "^2.0.1",
         },
       ];
-      rpcMock
-        .expects("invoke")
-        .withExactArgs("isGeneratorsPrompt")
-        .resolves(true);
+      rpcMock.expects("invoke").withExactArgs("isGeneratorsPrompt").resolves(true);
       youiEventsMock.expects("getAppWizard").returns(appWizard);
       appWizardMock
         .expects("showWarning")
-        .withExactArgs(
-          yeomanUi["uiOptions"].messages.generators_are_being_installed,
-          MessageType.prompt
-        );
+        .withExactArgs(yeomanUi["uiOptions"].messages.generators_are_being_installed, MessageType.prompt);
       appWizardMock.expects("showInformation").never();
       await yeomanUi._notifyGeneratorsInstall(args, false);
       expect(yeomanUi["uiOptions"].installGens).to.be.deep.equal(args);
@@ -523,17 +447,11 @@ describe("yeomanui unit test", () => {
           versionRange: "^2.0.1",
         },
       ];
-      rpcMock
-        .expects("invoke")
-        .withExactArgs("isGeneratorsPrompt")
-        .resolves(false);
+      rpcMock.expects("invoke").withExactArgs("isGeneratorsPrompt").resolves(false);
       youiEventsMock.expects("getAppWizard").returns(appWizard);
       appWizardMock
         .expects("showWarning")
-        .withExactArgs(
-          yeomanUi["uiOptions"].messages.generators_are_being_installed,
-          MessageType.prompt
-        );
+        .withExactArgs(yeomanUi["uiOptions"].messages.generators_are_being_installed, MessageType.prompt);
       appWizardMock.expects("showInformation").never();
       await yeomanUi._notifyGeneratorsInstall(args, true);
       expect(yeomanUi["uiOptions"].installGens).to.be.deep.equal(args);
@@ -553,10 +471,7 @@ describe("yeomanui unit test", () => {
           versionRange: "^2.0.1",
         },
       ];
-      rpcMock
-        .expects("invoke")
-        .withExactArgs("isGeneratorsPrompt")
-        .resolves(false);
+      rpcMock.expects("invoke").withExactArgs("isGeneratorsPrompt").resolves(false);
       youiEventsMock.expects("getAppWizard").never();
       appWizardMock.expects("showInformation").never();
       await yeomanUi._notifyGeneratorsInstall(args, false);
@@ -566,31 +481,19 @@ describe("yeomanui unit test", () => {
 
   describe("showGeneratorsInstallingMessage", () => {
     it("called with empty args array (install ended)", async () => {
-      const rpcInvokeStub = sandbox
-        .stub(rpc, "invoke")
-        .onFirstCall()
-        .resolves(true)
-        .onSecondCall()
-        .resolves();
+      const rpcInvokeStub = sandbox.stub(rpc, "invoke").onFirstCall().resolves(true).onSecondCall().resolves();
       appWizardMock.expects("showWarning").never();
       await yeomanUi._notifyGeneratorsInstall([], false);
       expect(rpcInvokeStub.callCount).to.equal(2);
-      expect(rpcInvokeStub.firstCall.args).to.deep.equal([
-        "isGeneratorsPrompt",
-      ]);
-      expect(rpcInvokeStub.secondCall.args).to.deep.equal([
-        "resetPromptMessage",
-      ]);
+      expect(rpcInvokeStub.firstCall.args).to.deep.equal(["isGeneratorsPrompt"]);
+      expect(rpcInvokeStub.secondCall.args).to.deep.equal(["resetPromptMessage"]);
       rpcInvokeStub.restore();
     });
     it("called with args array containing generators (install started)", () => {
       youiEventsMock.expects("getAppWizard").returns(appWizard);
       appWizardMock
         .expects("showWarning")
-        .withExactArgs(
-          yeomanUi["uiOptions"].messages.generators_are_being_installed,
-          MessageType.prompt
-        );
+        .withExactArgs(yeomanUi["uiOptions"].messages.generators_are_being_installed, MessageType.prompt);
       appWizardMock.expects("showInformation").never();
       void yeomanUi._notifyGeneratorsInstall([{}], true);
     });
@@ -652,16 +555,13 @@ describe("yeomanui unit test", () => {
           generatorPackageJson: {
             description: "test5Description",
           },
-        }
+        },
       ];
     });
 
     it("there are no generators", async () => {
       envUtilsMock.expects("getGeneratorsData").withExactArgs().resolves([]);
-      wsConfigMock
-        .expects("get")
-        .withExactArgs("ApplicationWizard.HideGenerator")
-        .returns("");
+      wsConfigMock.expects("get").withExactArgs("ApplicationWizard.HideGenerator").returns("");
       const result = await yeomanUi["getGeneratorsPrompt"]();
       const generatorQuestion: any = {
         type: "list",
@@ -687,7 +587,7 @@ describe("yeomanui unit test", () => {
         outputChannel,
         testLogger,
         { filter: GeneratorFilter.create(), messages },
-        flowPromise.state
+        flowPromise.state,
       );
       const noGeneratorsResult = {
         name: "Select Generator",
@@ -697,8 +597,7 @@ describe("yeomanui unit test", () => {
             guiType: "tiles",
             guiOptions: {
               breadcrumb: "",
-              hint: yeomanUi["uiOptions"].messages
-                .select_generator_question_hint,
+              hint: yeomanUi["uiOptions"].messages.select_generator_question_hint,
             },
             name: "generator",
             message: yeomanUi["uiOptions"].messages.channel_name,
@@ -720,14 +619,8 @@ describe("yeomanui unit test", () => {
             description: "test hidden category",
           },
         };
-        envUtilsMock
-          .expects("getGeneratorsData")
-          .withExactArgs()
-          .resolves([generatorData]);
-        wsConfigMock
-          .expects("get")
-          .withExactArgs("ApplicationWizard.HideGenerator")
-          .returns("");
+        envUtilsMock.expects("getGeneratorsData").withExactArgs().resolves([generatorData]);
+        wsConfigMock.expects("get").withExactArgs("ApplicationWizard.HideGenerator").returns("");
         const result = await yeomanUiInstance["getGeneratorsPrompt"]();
         expect(result).to.be.deep.equal(noGeneratorsResult);
         expect(result.questions[0].choices).to.be.empty;
@@ -749,10 +642,7 @@ describe("yeomanui unit test", () => {
           .expects("get")
           .withExactArgs("ApplicationWizard.HideGenerator")
           .returns("@ns/test1-project ,  other:app ");
-        envUtilsMock
-          .expects("getGeneratorsData")
-          .withExactArgs()
-          .resolves([generatorData]);
+        envUtilsMock.expects("getGeneratorsData").withExactArgs().resolves([generatorData]);
         const result = await yeomanUiInstance["getGeneratorsPrompt"]();
         expect(result).to.be.deep.equal(noGeneratorsResult);
         expect(result.questions[0].choices).to.be.empty;
@@ -768,14 +658,8 @@ describe("yeomanui unit test", () => {
             description: "test hidden category",
           },
         };
-        envUtilsMock
-          .expects("getGeneratorsData")
-          .withExactArgs()
-          .resolves([generatorData]);
-        wsConfigMock
-          .expects("get")
-          .withExactArgs("ApplicationWizard.HideGenerator")
-          .returns("");
+        envUtilsMock.expects("getGeneratorsData").withExactArgs().resolves([generatorData]);
+        wsConfigMock.expects("get").withExactArgs("ApplicationWizard.HideGenerator").returns("");
         const result = await yeomanUiInstance["getGeneratorsPrompt"]();
         expect(result).to.be.deep.equal(noGeneratorsResult);
         expect(result.questions[0].choices).to.be.empty;
@@ -790,14 +674,8 @@ describe("yeomanui unit test", () => {
             description,
           },
         };
-        envUtilsMock
-          .expects("getGeneratorsData")
-          .withExactArgs()
-          .resolves([generatorData]);
-        wsConfigMock
-          .expects("get")
-          .withExactArgs("ApplicationWizard.HideGenerator")
-          .returns("");
+        envUtilsMock.expects("getGeneratorsData").withExactArgs().resolves([generatorData]);
+        wsConfigMock.expects("get").withExactArgs("ApplicationWizard.HideGenerator").returns("");
         const result = await yeomanUiInstance["getGeneratorsPrompt"]();
         expect(result.questions[0].choices).to.have.lengthOf(1);
         const test1Choice = result.questions[0].choices[0];
@@ -807,31 +685,17 @@ describe("yeomanui unit test", () => {
     });
 
     it("get generators with type project", async () => {
-      wsConfigMock
-        .expects("get")
-        .withExactArgs("ApplicationWizard.Workspace")
-        .returns({});
-      wsConfigMock
-        .expects("get")
-        .withExactArgs("ApplicationWizard.HideGenerator")
-        .once()
-        .returns("");
-      envUtilsMock
-        .expects("getGeneratorsData")
-        .withExactArgs()
-        .resolves(gensMeta);
-      wsConfigMock
-        .expects("get")
-        .withExactArgs(yeomanUi["TARGET_FOLDER_CONFIG_PROP"]);
+      wsConfigMock.expects("get").withExactArgs("ApplicationWizard.Workspace").returns({});
+      wsConfigMock.expects("get").withExactArgs("ApplicationWizard.HideGenerator").once().returns("");
+      envUtilsMock.expects("getGeneratorsData").withExactArgs().resolves(gensMeta);
+      wsConfigMock.expects("get").withExactArgs(yeomanUi["TARGET_FOLDER_CONFIG_PROP"]);
       const genFilter: GeneratorFilter = GeneratorFilter.create({
         type: "project",
       });
       yeomanUi["uiOptions"] = { filter: genFilter, messages };
       const result: any = await yeomanUi["getGeneratorsPrompt"]();
 
-      const question = result.questions.find(
-        (question: { type: string }) => question.type === "list"
-      );
+      const question = result.questions.find((question: { type: string }) => question.type === "list");
       expect(question.choices).to.have.lengthOf(2);
       const test1Choice = question.choices[0];
       const test2Choice = question.choices[1];
@@ -842,14 +706,8 @@ describe("yeomanui unit test", () => {
     });
 
     it("get generators with type module", async () => {
-      envUtilsMock
-        .expects("getGeneratorsData")
-        .withExactArgs()
-        .resolves(gensMeta);
-      wsConfigMock
-        .expects("get")
-        .withExactArgs("ApplicationWizard.HideGenerator")
-        .returns("");
+      envUtilsMock.expects("getGeneratorsData").withExactArgs().resolves(gensMeta);
+      wsConfigMock.expects("get").withExactArgs("ApplicationWizard.HideGenerator").returns("");
       const genFilter = GeneratorFilter.create({ type: "module" });
       yeomanUi["uiOptions"] = { filter: genFilter, messages };
       const result = await yeomanUi["getGeneratorsPrompt"]();
@@ -862,10 +720,7 @@ describe("yeomanui unit test", () => {
 
     it("get generators all generators", async () => {
       envUtilsMock.expects("getGeneratorsData").resolves(gensMeta);
-      wsConfigMock
-        .expects("get")
-        .withExactArgs("ApplicationWizard.HideGenerator")
-        .returns("");
+      wsConfigMock.expects("get").withExactArgs("ApplicationWizard.HideGenerator").returns("");
       yeomanUi["uiOptions"] = {
         filter: GeneratorFilter.create({ type: [] }),
         messages,
@@ -917,11 +772,13 @@ describe("yeomanui unit test", () => {
           generatorPackageJson: {
             "generator-filter": { type: "project" },
             description: "test4Description",
-            additional_generators: [{
-              namespace: "test4:subgen",
-              description: "test 4 sub gen description",
-              displayName: "Test Sub Gen 4"
-            }]
+            additional_generators: [
+              {
+                namespace: "test4:subgen",
+                description: "test 4 sub gen description",
+                displayName: "Test Sub Gen 4",
+              },
+            ],
           },
         },
         {
@@ -929,24 +786,23 @@ describe("yeomanui unit test", () => {
             generatorPath: "test4Path/subgen/index.js",
             namespace: "test4:subgen",
             packagePath: "test4Path",
-            isAdditional: true
+            isAdditional: true,
           },
           generatorPackageJson: {
             description: "test5Description",
-            additional_generators: [{
-              namespace: "test4:subgen",
-              description: "test 4 sub gen description",
-              displayName: "Test Sub Gen 4"
-            }]
+            additional_generators: [
+              {
+                namespace: "test4:subgen",
+                description: "test 4 sub gen description",
+                displayName: "Test Sub Gen 4",
+              },
+            ],
           },
-        }
+        },
       ];
 
       envUtilsMock.expects("getGeneratorsData").resolves(gensMeta);
-      wsConfigMock
-        .expects("get")
-        .withExactArgs("ApplicationWizard.HideGenerator")
-        .returns("");
+      wsConfigMock.expects("get").withExactArgs("ApplicationWizard.HideGenerator").returns("");
       yeomanUi["uiOptions"] = {
         filter: GeneratorFilter.create({ type: [] }),
         messages,
@@ -957,14 +813,8 @@ describe("yeomanui unit test", () => {
     });
 
     it("wrong generators filter type is provided", async () => {
-      wsConfigMock
-        .expects("get")
-        .withExactArgs("ApplicationWizard.Workspace")
-        .returns({});
-      wsConfigMock
-        .expects("get")
-        .withExactArgs("ApplicationWizard.HideGenerator")
-        .returns("");
+      wsConfigMock.expects("get").withExactArgs("ApplicationWizard.Workspace").returns({});
+      wsConfigMock.expects("get").withExactArgs("ApplicationWizard.HideGenerator").returns("");
       envUtilsMock
         .expects("getGeneratorsData")
         .withExactArgs()
@@ -982,30 +832,20 @@ describe("yeomanui unit test", () => {
           },
         ]);
 
-      wsConfigMock
-        .expects("get")
-        .withExactArgs(yeomanUi["TARGET_FOLDER_CONFIG_PROP"]);
+      wsConfigMock.expects("get").withExactArgs(yeomanUi["TARGET_FOLDER_CONFIG_PROP"]);
       yeomanUi["uiOptions"] = {
         filter: GeneratorFilter.create({ type: "project" }),
         messages,
       };
       const result = await yeomanUi["getGeneratorsPrompt"]();
 
-      const question = result.questions.find(
-        (question: { type: string }) => question.type === "list"
-      );
+      const question = result.questions.find((question: { type: string }) => question.type === "list");
       expect(question.choices).to.be.empty;
     });
 
     it("get generators with type project and categories cat1 and cat2", async () => {
-      wsConfigMock
-        .expects("get")
-        .withExactArgs("ApplicationWizard.Workspace")
-        .returns({});
-      wsConfigMock
-        .expects("get")
-        .withExactArgs("ApplicationWizard.HideGenerator")
-        .returns("");
+      wsConfigMock.expects("get").withExactArgs("ApplicationWizard.Workspace").returns({});
+      wsConfigMock.expects("get").withExactArgs("ApplicationWizard.HideGenerator").returns("");
       gensMeta[0].generatorPackageJson = {
         "generator-filter": { type: ["project"], categories: ["cat2"] },
         description: "test1Description",
@@ -1020,24 +860,17 @@ describe("yeomanui unit test", () => {
         "generator-filter": { type: "project", categories: ["cat1"] },
         description: "test4Description",
       };
-      envUtilsMock
-        .expects("getGeneratorsData")
-        .withExactArgs()
-        .resolves(gensMeta);
+      envUtilsMock.expects("getGeneratorsData").withExactArgs().resolves(gensMeta);
 
       const genFilter: GeneratorFilter = GeneratorFilter.create({
         type: ["project"],
         categories: ["cat1", "cat2"],
       });
       yeomanUi["uiOptions"].filter = genFilter;
-      wsConfigMock
-        .expects("get")
-        .withExactArgs(yeomanUi["TARGET_FOLDER_CONFIG_PROP"]);
+      wsConfigMock.expects("get").withExactArgs(yeomanUi["TARGET_FOLDER_CONFIG_PROP"]);
       const result = await yeomanUi["getGeneratorsPrompt"]();
 
-      const question = result.questions.find(
-        (question: { type: string }) => question.type === "list"
-      );
+      const question = result.questions.find((question: { type: string }) => question.type === "list");
       expect(question.choices).to.have.lengthOf(3);
       const test1Choice = question.choices[0];
       const test2Choice = question.choices[1];
@@ -1052,14 +885,8 @@ describe("yeomanui unit test", () => {
         description: "test3Description",
         displayName: "3rd - Test",
       };
-      envUtilsMock
-        .expects("getGeneratorsData")
-        .withExactArgs()
-        .resolves(gensMeta.slice(0, 3));
-      wsConfigMock
-        .expects("get")
-        .withExactArgs("ApplicationWizard.HideGenerator")
-        .returns("");
+      envUtilsMock.expects("getGeneratorsData").withExactArgs().resolves(gensMeta.slice(0, 3));
+      wsConfigMock.expects("get").withExactArgs("ApplicationWizard.HideGenerator").returns("");
 
       yeomanUi["uiOptions"] = {
         filter: GeneratorFilter.create({ type: undefined }),
@@ -1089,14 +916,8 @@ describe("yeomanui unit test", () => {
         homepage: "https://myhomepage.com/ANY/generator-test2-module#readme",
       };
 
-      envUtilsMock
-        .expects("getGeneratorsData")
-        .withExactArgs()
-        .resolves(gensMeta.slice(0, 3));
-      wsConfigMock
-        .expects("get")
-        .withExactArgs("ApplicationWizard.HideGenerator")
-        .returns("");
+      envUtilsMock.expects("getGeneratorsData").withExactArgs().resolves(gensMeta.slice(0, 3));
+      wsConfigMock.expects("get").withExactArgs("ApplicationWizard.HideGenerator").returns("");
 
       yeomanUi["uiOptions"] = { filter: GeneratorFilter.create(), messages };
       const result = await yeomanUi["getGeneratorsPrompt"]();
@@ -1106,40 +927,24 @@ describe("yeomanui unit test", () => {
       const test1Choice = choices[0];
       const test2Choice = choices[1];
       const test3Choice = choices[2];
-      expect(test1Choice.homepage).to.be.equal(
-        "https://myhomepage.com/ANY/generator-test1-project#readme"
-      );
-      expect(test2Choice.homepage).to.be.equal(
-        "https://myhomepage.com/ANY/generator-test2-module#readme"
-      );
+      expect(test1Choice.homepage).to.be.equal("https://myhomepage.com/ANY/generator-test1-project#readme");
+      expect(test2Choice.homepage).to.be.equal("https://myhomepage.com/ANY/generator-test2-module#readme");
       expect(test3Choice.homepage).to.be.equal("");
     });
 
     it("generator with type project", async () => {
-      envUtilsMock
-        .expects("getGeneratorsData")
-        .withExactArgs()
-        .resolves(gensMeta.slice(0, 1));
+      envUtilsMock.expects("getGeneratorsData").withExactArgs().resolves(gensMeta.slice(0, 1));
       sandbox
         .stub(vscode.workspace, "workspaceFolders")
-        .value([
-          { uri: { fsPath: "rootFolderPath" } },
-          { uri: { fsPath: "testRoot" } },
-        ]);
+        .value([{ uri: { fsPath: "rootFolderPath" } }, { uri: { fsPath: "testRoot" } }]);
 
       yeomanUi["uiOptions"] = {
         filter: GeneratorFilter.create({ type: "project" }),
         messages,
       };
-      wsConfigMock
-        .expects("get")
-        .withExactArgs(yeomanUi["TARGET_FOLDER_CONFIG_PROP"]);
-      wsConfigMock
-        .expects("get")
-        .withExactArgs(yeomanUi["SELECTED_WORKSPACE_CONFIG_PROP"]);
-      wsConfigMock
-        .expects("get")
-        .withExactArgs(yeomanUi["HIDE_GENERATORS_PROP"]);
+      wsConfigMock.expects("get").withExactArgs(yeomanUi["TARGET_FOLDER_CONFIG_PROP"]);
+      wsConfigMock.expects("get").withExactArgs(yeomanUi["SELECTED_WORKSPACE_CONFIG_PROP"]);
+      wsConfigMock.expects("get").withExactArgs(yeomanUi["HIDE_GENERATORS_PROP"]);
 
       await yeomanUi["getGeneratorsPrompt"]();
     });
@@ -1149,34 +954,19 @@ describe("yeomanui unit test", () => {
         "generator-filter": { type: "tools-suite" },
         description: "test4Description",
       };
-      envUtilsMock
-        .expects("getGeneratorsData")
-        .withExactArgs()
-        .resolves(gensMeta.slice(0, 1));
+      envUtilsMock.expects("getGeneratorsData").withExactArgs().resolves(gensMeta.slice(0, 1));
       sandbox
         .stub(vscode.workspace, "workspaceFolders")
-        .value([
-          { uri: { fsPath: "rootFolderPath" } },
-          { uri: { fsPath: "testRoot" } },
-        ]);
-      wsConfigMock
-        .expects("get")
-        .withExactArgs(yeomanUi["TARGET_FOLDER_CONFIG_PROP"]);
-      wsConfigMock
-        .expects("get")
-        .withExactArgs(yeomanUi["SELECTED_WORKSPACE_CONFIG_PROP"]);
-      wsConfigMock
-        .expects("get")
-        .withExactArgs("ApplicationWizard.HideGenerator")
-        .returns("gen1,gen2,gen3");
+        .value([{ uri: { fsPath: "rootFolderPath" } }, { uri: { fsPath: "testRoot" } }]);
+      wsConfigMock.expects("get").withExactArgs(yeomanUi["TARGET_FOLDER_CONFIG_PROP"]);
+      wsConfigMock.expects("get").withExactArgs(yeomanUi["SELECTED_WORKSPACE_CONFIG_PROP"]);
+      wsConfigMock.expects("get").withExactArgs("ApplicationWizard.HideGenerator").returns("gen1,gen2,gen3");
       yeomanUi["uiOptions"] = {
         filter: GeneratorFilter.create({ type: "project" }),
         messages,
       };
       await yeomanUi["getGeneratorsPrompt"]();
-      expect(yeomanUi["generatorsToIgnoreArray"]).to.be.contains(
-        "test1-project:app"
-      );
+      expect(yeomanUi["generatorsToIgnoreArray"]).to.be.contains("test1-project:app");
     });
   });
 
@@ -1195,21 +985,12 @@ describe("yeomanui unit test", () => {
   });
 
   describe("getCwd", () => {
-    const yeomanUiInstance: YeomanUI = new YeomanUI(
-      rpc,
-      youiEvents,
-      outputChannel,
-      testLogger,
-      {},
-      flowPromise.state
-    );
+    const yeomanUiInstance: YeomanUI = new YeomanUI(rpc, youiEvents, outputChannel, testLogger, {}, flowPromise.state);
 
     it("in VSCODE, target folder is undefined", () => {
       Constants.IS_IN_BAS = false;
       _.set(vscode, "workspace.workspaceFolders[0].uri.fsPath", undefined);
-      wsConfigMock
-        .expects("get")
-        .withExactArgs(yeomanUiInstance["TARGET_FOLDER_CONFIG_PROP"]);
+      wsConfigMock.expects("get").withExactArgs(yeomanUiInstance["TARGET_FOLDER_CONFIG_PROP"]);
       const res = yeomanUiInstance["getCwd"]();
       expect(res).equal(Constants.HOMEDIR_PROJECTS);
     });
@@ -1217,10 +998,7 @@ describe("yeomanui unit test", () => {
     it("in VSCODE, target folder is empty non-zero length string", () => {
       Constants.IS_IN_BAS = false;
       _.set(vscode, "workspace.workspaceFolders[0].uri.fsPath", undefined);
-      wsConfigMock
-        .expects("get")
-        .withExactArgs(yeomanUiInstance["TARGET_FOLDER_CONFIG_PROP"])
-        .returns("     ");
+      wsConfigMock.expects("get").withExactArgs(yeomanUiInstance["TARGET_FOLDER_CONFIG_PROP"]).returns("     ");
       const res = yeomanUiInstance["getCwd"]();
       expect(res).equal(Constants.HOMEDIR_PROJECTS);
     });
@@ -1240,14 +1018,8 @@ describe("yeomanui unit test", () => {
     it("in VSCODE, a folder is opened", () => {
       Constants.IS_IN_BAS = false;
       const openedVscodeFolderPath = "/home/user/folder/folder2";
-      _.set(
-        vscode,
-        "workspace.workspaceFolders[0].uri.fsPath",
-        openedVscodeFolderPath
-      );
-      wsConfigMock
-        .expects("get")
-        .withExactArgs(yeomanUiInstance["TARGET_FOLDER_CONFIG_PROP"]);
+      _.set(vscode, "workspace.workspaceFolders[0].uri.fsPath", openedVscodeFolderPath);
+      wsConfigMock.expects("get").withExactArgs(yeomanUiInstance["TARGET_FOLDER_CONFIG_PROP"]);
       const res = yeomanUiInstance["getCwd"]();
       expect(res).equal(openedVscodeFolderPath);
     });
@@ -1255,9 +1027,7 @@ describe("yeomanui unit test", () => {
     it("in BAS, target folder is undefined", () => {
       Constants.IS_IN_BAS = true;
       _.set(vscode, "workspace.workspaceFolders[0].uri.fsPath", undefined);
-      wsConfigMock
-        .expects("get")
-        .withExactArgs(yeomanUiInstance["TARGET_FOLDER_CONFIG_PROP"]);
+      wsConfigMock.expects("get").withExactArgs(yeomanUiInstance["TARGET_FOLDER_CONFIG_PROP"]);
       const res = yeomanUiInstance["getCwd"]();
       expect(res).equal(Constants.HOMEDIR_PROJECTS);
     });
@@ -1265,10 +1035,7 @@ describe("yeomanui unit test", () => {
     it("in BAS, target folder is empty non-zero length string", () => {
       Constants.IS_IN_BAS = true;
       _.set(vscode, "workspace.workspaceFolders[0].uri.fsPath", undefined);
-      wsConfigMock
-        .expects("get")
-        .withExactArgs(yeomanUiInstance["TARGET_FOLDER_CONFIG_PROP"])
-        .returns("     ");
+      wsConfigMock.expects("get").withExactArgs(yeomanUiInstance["TARGET_FOLDER_CONFIG_PROP"]).returns("     ");
       const res = yeomanUiInstance["getCwd"]();
       expect(res).equal(Constants.HOMEDIR_PROJECTS);
     });
@@ -1293,7 +1060,7 @@ describe("yeomanui unit test", () => {
       outputChannel,
       testLogger,
       null,
-      flowPromise.state
+      flowPromise.state,
     );
     const errorInfo = "Error Info";
     const res = yeomanUiInstance["getErrorInfo"](errorInfo);
@@ -1302,11 +1069,7 @@ describe("yeomanui unit test", () => {
 
   describe("answersUtils", () => {
     it("setDefaults", () => {
-      const questions = [
-        { name: "q1", default: "a" },
-        { name: "q2", default: () => "b" },
-        { name: "q3" },
-      ];
+      const questions = [{ name: "q1", default: "a" }, { name: "q2", default: () => "b" }, { name: "q3" }];
       const answers = {
         q1: "x",
         q2: "y",
@@ -1314,19 +1077,13 @@ describe("yeomanui unit test", () => {
       };
       ReplayUtils["setDefaults"](questions, answers);
       for (const question of questions) {
-        expect((question as any)["__origAnswer"]).to.equal(
-          (<any>answers)[question.name]
-        );
+        expect((question as any)["__origAnswer"]).to.equal((<any>answers)[question.name]);
         expect((question as any)["__ForceDefault"]).to.be.true;
       }
     });
 
     it("setDefaults", () => {
-      const questions = [
-        { name: "q1", default: "a" },
-        { name: "q2", default: () => "b" },
-        { name: "q3" },
-      ];
+      const questions = [{ name: "q1", default: "a" }, { name: "q2", default: () => "b" }, { name: "q3" }];
       const answers = {
         q1: "x",
         q3: "z",
@@ -1339,14 +1096,7 @@ describe("yeomanui unit test", () => {
   });
 
   it("handleErrors", () => {
-    const yeomanUiInstance: YeomanUI = new YeomanUI(
-      rpc,
-      youiEvents,
-      outputChannel,
-      testLogger,
-      {},
-      flowPromise.state
-    );
+    const yeomanUiInstance: YeomanUI = new YeomanUI(rpc, youiEvents, outputChannel, testLogger, {}, flowPromise.state);
     const env: Environment = Environment.createEnv();
     const envMock = sandbox.mock(env);
     const gen = { on: () => "" };
@@ -1363,14 +1113,7 @@ describe("yeomanui unit test", () => {
   });
 
   it("handleErrors - when 'startOver' operation selected", () => {
-    const yeomanUiInstance: YeomanUI = new YeomanUI(
-      rpc,
-      youiEvents,
-      outputChannel,
-      testLogger,
-      {},
-      flowPromise.state
-    );
+    const yeomanUiInstance: YeomanUI = new YeomanUI(rpc, youiEvents, outputChannel, testLogger, {}, flowPromise.state);
     yeomanUiInstance["onUncaughtException"] = () => "";
     const onUncaughtExceptionBefore = yeomanUiInstance["onUncaughtException"];
     const env: Environment = Environment.createEnv();
@@ -1381,30 +1124,19 @@ describe("yeomanui unit test", () => {
     envMock.expects("on").withArgs("error");
     genMock.expects("on").withArgs("error");
     processMock.expects("on").withArgs("uncaughtException");
-    processMock
-      .expects("removeListener")
-      .withArgs("uncaughtException", onUncaughtExceptionBefore);
+    processMock.expects("removeListener").withArgs("uncaughtException", onUncaughtExceptionBefore);
     yeomanUiInstance["handleErrors"](env, gen, "genName");
     envMock.verify();
     genMock.verify();
     processMock.verify();
     expect(yeomanUiInstance["onUncaughtException"]).to.be.ok;
-    expect(yeomanUiInstance["onUncaughtException"]).to.not.equal(
-      onUncaughtExceptionBefore
-    );
+    expect(yeomanUiInstance["onUncaughtException"]).to.not.equal(onUncaughtExceptionBefore);
   });
 
   describe("setGenInWriting", () => {
     let genMock: any;
     let rpcMock: any;
-    const yeomanUiInstance: YeomanUI = new YeomanUI(
-      rpc,
-      youiEvents,
-      outputChannel,
-      testLogger,
-      {},
-      flowPromise.state
-    );
+    const yeomanUiInstance: YeomanUI = new YeomanUI(rpc, youiEvents, outputChannel, testLogger, {}, flowPromise.state);
     const gen: any = { on: () => "" };
 
     beforeEach(() => {
@@ -1430,18 +1162,8 @@ describe("yeomanui unit test", () => {
   });
 
   it("exploreGenerators", () => {
-    const yeomanUiInstance: YeomanUI = new YeomanUI(
-      rpc,
-      youiEvents,
-      outputChannel,
-      testLogger,
-      {},
-      flowPromise.state
-    );
-    commandsMock
-      .expects("executeCommand")
-      .withExactArgs("exploreGenerators")
-      .resolves();
+    const yeomanUiInstance: YeomanUI = new YeomanUI(rpc, youiEvents, outputChannel, testLogger, {}, flowPromise.state);
+    commandsMock.expects("executeCommand").withExactArgs("exploreGenerators").resolves();
     yeomanUiInstance["exploreGenerators"]();
   });
 
@@ -1452,7 +1174,7 @@ describe("yeomanui unit test", () => {
       outputChannel,
       testLogger,
       GeneratorFilter.create(),
-      flowPromise.state
+      flowPromise.state,
     );
     const gen: any = { on: () => "" };
     const genMock = sandbox.mock(gen);
@@ -1477,7 +1199,7 @@ describe("yeomanui unit test", () => {
         outputChannel,
         testLogger,
         GeneratorFilter.create(),
-        flowPromise.state
+        flowPromise.state,
       );
       const questions = [{ name: "q1" }];
       const response = await yeomanUiInstance.showPrompt(questions);
@@ -1490,7 +1212,7 @@ describe("yeomanui unit test", () => {
 
       (rpc.invoke as (methodName: string, params: any[]) => Promise<any>) = (
         methodName: string,
-        params: any[]
+        params: any[],
       ): Promise<unknown> => {
         const questionName: string = params[0][0].name;
         if (questionName === "q1") {
@@ -1510,7 +1232,7 @@ describe("yeomanui unit test", () => {
         outputChannel,
         testLogger,
         GeneratorFilter.create(),
-        flowPromise.state
+        flowPromise.state,
       );
       yeomanUiInstance["runGenerator"] = (): Promise<any> => {
         return Promise.resolve();
@@ -1560,24 +1282,17 @@ describe("yeomanui unit test", () => {
         targetFolderPath: path.join("/", "testDestinationRoot"),
         changeMap: changes,
       };
-      trackerWrapperMock
-        .expects("updateGeneratorEnded")
-        .withArgs("testGenName")
-        .resolves();
+      trackerWrapperMock.expects("updateGeneratorEnded").withArgs("testGenName").resolves();
       yeomanUi["onGeneratorSuccess"]("testGenName", beforeGen, afterGen);
       expect(
         doGeneratorDoneSpy.calledWith(
           true,
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          _.get(
-            yeomanUi,
-            "uiOptions.messages.artifact_with_name_generated",
-            (a: string) => ""
-          )("testGenName"),
+          _.get(yeomanUi, "uiOptions.messages.artifact_with_name_generated", (a: string) => "")("testGenName"),
           create_and_close,
           "files",
-          path.join(beforeGen.targetFolderPath, "dirpath1")
-        )
+          path.join(beforeGen.targetFolderPath, "dirpath1"),
+        ),
       ).to.be.true;
     });
 
@@ -1595,24 +1310,17 @@ describe("yeomanui unit test", () => {
         targetFolderPath: path.join("/", "testDestinationRoot"),
         changeMap: changes,
       };
-      trackerWrapperMock
-        .expects("updateGeneratorEnded")
-        .withArgs("testGenName")
-        .resolves();
+      trackerWrapperMock.expects("updateGeneratorEnded").withArgs("testGenName").resolves();
       yeomanUi["onGeneratorSuccess"]("testGenName", beforeGen, afterGen);
       expect(
         doGeneratorDoneSpy.calledWith(
           true,
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          _.get(
-            yeomanUi,
-            "uiOptions.messages.artifact_with_name_generated",
-            (a: string) => ""
-          )("testGenName"),
+          _.get(yeomanUi, "uiOptions.messages.artifact_with_name_generated", (a: string) => "")("testGenName"),
           create_and_close,
           "files",
-          null
-        )
+          null,
+        ),
       ).to.be.true;
     });
 
@@ -1624,24 +1332,17 @@ describe("yeomanui unit test", () => {
         targetFolderPath: "testDestinationRoot",
         changeMap: changes,
       };
-      trackerWrapperMock
-        .expects("updateGeneratorEnded")
-        .withArgs("testGenName")
-        .resolves();
+      trackerWrapperMock.expects("updateGeneratorEnded").withArgs("testGenName").resolves();
       yeomanUi["onGeneratorSuccess"]("testGenName", beforeGen, afterGen);
       expect(
         doGeneratorDoneSpy.calledWith(
           true,
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          _.get(
-            yeomanUi,
-            "uiOptions.messages.artifact_with_name_generated",
-            (a: string) => ""
-          )("testGenName"),
+          _.get(yeomanUi, "uiOptions.messages.artifact_with_name_generated", (a: string) => "")("testGenName"),
           create_and_close,
           "",
-          null
-        )
+          null,
+        ),
       ).to.be.true;
     });
 
@@ -1652,83 +1353,54 @@ describe("yeomanui unit test", () => {
       changes.set(path.join("/", "testDestinationRoot", "webapp", "changes"), {
         isDirectory: true,
       });
-      changes.set(
-        path.join("/", "testDestinationRoot", "webapp", "changes", "file1"),
-        { isDirectory: false }
-      );
+      changes.set(path.join("/", "testDestinationRoot", "webapp", "changes", "file1"), { isDirectory: false });
       const afterGen = {
         targetFolderPath: "testDestinationRoot",
         changeMap: changes,
       };
-      trackerWrapperMock
-        .expects("updateGeneratorEnded")
-        .withArgs("testGenName")
-        .resolves();
+      trackerWrapperMock.expects("updateGeneratorEnded").withArgs("testGenName").resolves();
       yeomanUi["onGeneratorSuccess"]("testGenName", beforeGen, afterGen);
       expect(
         doGeneratorDoneSpy.calledWith(
           true,
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          _.get(
-            yeomanUi,
-            "uiOptions.messages.artifact_with_name_generated",
-            (a: string) => ""
-          )("testGenName"),
+          _.get(yeomanUi, "uiOptions.messages.artifact_with_name_generated", (a: string) => "")("testGenName"),
           create_and_close,
           "files",
-          null
-        )
+          null,
+        ),
       ).to.be.true;
     });
 
     it("onGeneratorSuccess - targetFolderPath was changed by generator", () => {
       const beforeGen = { targetFolderPath: "testDestinationRoot" };
       const afterGen = {
-        targetFolderPath: path.join(
-          "/",
-          "testDestinationRoot",
-          "generatedProject"
-        ),
+        targetFolderPath: path.join("/", "testDestinationRoot", "generatedProject"),
         changeMap: changes,
       };
-      trackerWrapperMock
-        .expects("updateGeneratorEnded")
-        .withArgs("testGenName")
-        .resolves();
+      trackerWrapperMock.expects("updateGeneratorEnded").withArgs("testGenName").resolves();
       yeomanUi["onGeneratorSuccess"]("testGenName", beforeGen, afterGen);
       expect(
         doGeneratorDoneSpy.calledWith(
           true,
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          _.get(
-            yeomanUi,
-            "uiOptions.messages.artifact_with_name_generated",
-            (a: string) => ""
-          )("testGenName"),
+          _.get(yeomanUi, "uiOptions.messages.artifact_with_name_generated", (a: string) => "")("testGenName"),
           create_and_close,
           "files",
-          afterGen.targetFolderPath
-        )
+          afterGen.targetFolderPath,
+        ),
       ).to.be.true;
     });
 
     it("onGeneratorFailure", () => {
       yeomanUi["onGeneratorFailure"]("testGenName", "testError");
       expect(
-        doGeneratorDoneSpy.calledWith(
-          false,
-          `{"message":"testGenName generator failed - testError"}`,
-          "",
-          "files"
-        )
+        doGeneratorDoneSpy.calledWith(false, `{"message":"testGenName generator failed - testError"}`, "", "files"),
       ).to.be.true;
     });
 
     it("onGeneratorSuccess - generator type is project", () => {
-      wsConfigMock
-        .expects("get")
-        .withExactArgs("ApplicationWizard.Workspace")
-        .returns(open_in_new_ws);
+      wsConfigMock.expects("get").withExactArgs("ApplicationWizard.Workspace").returns(open_in_new_ws);
       yeomanUi["typesMap"].clear();
       yeomanUi["typesMap"].set("foodq:app", "project");
       const beforeGen = { targetFolderPath: "testDestinationRoot" };
@@ -1736,24 +1408,17 @@ describe("yeomanui unit test", () => {
         targetFolderPath: path.join("testDestinationRoot", "generatedProject"),
         changeMap: changes,
       };
-      trackerWrapperMock
-        .expects("updateGeneratorEnded")
-        .withArgs("foodq:app")
-        .resolves();
+      trackerWrapperMock.expects("updateGeneratorEnded").withArgs("foodq:app").resolves();
       yeomanUi["onGeneratorSuccess"]("foodq:app", beforeGen, afterGen);
       expect(
         doGeneratorDoneSpy.calledWith(
           true,
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          _.get(
-            yeomanUi,
-            "uiOptions.messages.artifact_with_name_generated",
-            (a: string) => ""
-          )("foodq:app"),
+          _.get(yeomanUi, "uiOptions.messages.artifact_with_name_generated", (a: string) => "")("foodq:app"),
           open_in_new_ws,
           "project",
-          afterGen.targetFolderPath
-        )
+          afterGen.targetFolderPath,
+        ),
       ).to.be.true;
     });
 
@@ -1766,28 +1431,17 @@ describe("yeomanui unit test", () => {
         targetFolderPath: "testDestinationRoot/generatedProject",
         changeMap: changes,
       };
-      trackerWrapperMock
-        .expects("updateGeneratorEnded")
-        .withArgs("fiori-generator:app")
-        .resolves();
-      yeomanUi["onGeneratorSuccess"](
-        "fiori-generator:app",
-        beforeGen,
-        afterGen
-      );
+      trackerWrapperMock.expects("updateGeneratorEnded").withArgs("fiori-generator:app").resolves();
+      yeomanUi["onGeneratorSuccess"]("fiori-generator:app", beforeGen, afterGen);
       expect(
         doGeneratorDoneSpy.calledWith(
           true,
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          _.get(
-            yeomanUi,
-            "uiOptions.messages.artifact_with_name_generated",
-            (a: string) => ""
-          )("fiori-generator:app"),
+          _.get(yeomanUi, "uiOptions.messages.artifact_with_name_generated", (a: string) => "")("fiori-generator:app"),
           create_and_close,
           "project",
-          afterGen.targetFolderPath
-        )
+          afterGen.targetFolderPath,
+        ),
       ).to.be.true;
     });
   });
@@ -1809,17 +1463,13 @@ describe("yeomanui unit test", () => {
         outputChannel,
         testLogger,
         GeneratorFilter.create(),
-        flowPromise.state
+        flowPromise.state,
       );
 
       yeomanUiInstance["addCustomQuestionEventHandlers"](questions);
       expect(questions[0]).to.not.have.property("testEvent");
 
-      yeomanUiInstance.registerCustomQuestionEventHandler(
-        "questionType",
-        "testEvent",
-        testEventFunction
-      );
+      yeomanUiInstance.registerCustomQuestionEventHandler("questionType", "testEvent", testEventFunction);
       yeomanUiInstance["addCustomQuestionEventHandlers"](questions);
       expect(questions[0]).to.have.property("testEvent");
       expect((questions[0] as any)["testEvent"]).to.equal(testEventFunction);
@@ -1838,21 +1488,11 @@ describe("yeomanui unit test", () => {
         testLogger,
         GeneratorFilter.create(),
 
-        flowPromise.state
+        flowPromise.state,
       );
-      yeomanUiInstance.registerCustomQuestionEventHandler(
-        "questionType",
-        "testEvent",
-        testEventFunction
-      );
-      yeomanUiInstance["currentQuestions"] = [
-        { name: "question1", guiType: "questionType" },
-      ];
-      const response = await yeomanUiInstance["evaluateMethod"](
-        null,
-        "question1",
-        "testEvent"
-      );
+      yeomanUiInstance.registerCustomQuestionEventHandler("questionType", "testEvent", testEventFunction);
+      yeomanUiInstance["currentQuestions"] = [{ name: "question1", guiType: "questionType" }];
+      const response = await yeomanUiInstance["evaluateMethod"](null, "question1", "testEvent");
       expect(response).to.be.true;
     });
 
@@ -1863,7 +1503,7 @@ describe("yeomanui unit test", () => {
         outputChannel,
         testLogger,
         GeneratorFilter.create(),
-        flowPromise.state
+        flowPromise.state,
       );
       yeomanUiInstance["currentQuestions"] = [
         {
@@ -1873,11 +1513,7 @@ describe("yeomanui unit test", () => {
           },
         },
       ];
-      const response = await yeomanUiInstance["evaluateMethod"](
-        null,
-        "question1",
-        "method1"
-      );
+      const response = await yeomanUiInstance["evaluateMethod"](null, "question1", "method1");
       expect(response).to.be.true;
     });
 
@@ -1888,13 +1524,9 @@ describe("yeomanui unit test", () => {
         outputChannel,
         testLogger,
         GeneratorFilter.create(),
-        flowPromise.state
+        flowPromise.state,
       );
-      const response = await yeomanUiInstance["evaluateMethod"](
-        null,
-        "question1",
-        "method1"
-      );
+      const response = await yeomanUiInstance["evaluateMethod"](null, "question1", "method1");
       expect(response).to.be.undefined;
     });
 
@@ -1905,7 +1537,7 @@ describe("yeomanui unit test", () => {
         outputChannel,
         testLogger,
         GeneratorFilter.create(),
-        flowPromise.state
+        flowPromise.state,
       );
       yeomanUiInstance["gen"] = Object.create({});
       yeomanUiInstance["gen"].options = {};
@@ -1931,7 +1563,7 @@ describe("yeomanui unit test", () => {
         outputChannel,
         testLogger,
         GeneratorFilter.create(),
-        flowPromise.state
+        flowPromise.state,
       );
       yeomanUiInstance["gen"] = Object.create({});
       yeomanUiInstance["gen"].options = {};

--- a/packages/backend/test/yeomanui.spec.ts
+++ b/packages/backend/test/yeomanui.spec.ts
@@ -8,7 +8,11 @@ import * as _ from "lodash";
 import { YeomanUI } from "../src/yeomanui";
 import { ReplayUtils } from "../src/replayUtils";
 import { YouiEvents } from "../src/youi-events";
-import { IMethod, IPromiseCallbacks, IRpc } from "@sap-devx/webview-rpc/out.ext/rpc-common";
+import {
+  IMethod,
+  IPromiseCallbacks,
+  IRpc,
+} from "@sap-devx/webview-rpc/out.ext/rpc-common";
 import { GeneratorFilter } from "../src/filter";
 import messages from "../src/messages";
 import { AnalyticsWrapper } from "../src/usage-report/usage-analytics-wrapper";
@@ -134,7 +138,7 @@ describe("yeomanui unit test", () => {
     outputChannel,
     testLogger,
     { filter: GeneratorFilter.create(), messages },
-    flowPromise.state,
+    flowPromise.state
   );
 
   before(() => {
@@ -180,12 +184,16 @@ describe("yeomanui unit test", () => {
 
     beforeEach(() => {
       stubStat = sandbox.stub(fs, "statSync");
-      sandbox.stub(fs, "watch").value((p: string, o: any, cb: (event: string, file: string) => void) => {
-        callBack = cb;
-        return {
-          close: () => {},
-        };
-      });
+      sandbox
+        .stub(fs, "watch")
+        .value(
+          (p: string, o: any, cb: (event: string, file: string) => void) => {
+            callBack = cb;
+            return {
+              close: () => { },
+            };
+          }
+        );
     });
 
     afterEach(() => {
@@ -197,9 +205,15 @@ describe("yeomanui unit test", () => {
       const folderPath = path.join("testPath");
       const subFolderPath = path.join(folderPath, "subFolderPath");
       const filePath = path.join(subFolderPath, "file1");
-      stubStat.withArgs(path.join(targetPath, folderPath)).returns({ isDirectory: () => true });
-      stubStat.withArgs(path.join(targetPath, subFolderPath)).returns({ isDirectory: () => true });
-      stubStat.withArgs(path.join(targetPath, filePath)).returns({ isDirectory: () => false, size: 100, mtime: 1233 });
+      stubStat
+        .withArgs(path.join(targetPath, folderPath))
+        .returns({ isDirectory: () => true });
+      stubStat
+        .withArgs(path.join(targetPath, subFolderPath))
+        .returns({ isDirectory: () => true });
+      stubStat
+        .withArgs(path.join(targetPath, filePath))
+        .returns({ isDirectory: () => false, size: 100, mtime: 1233 });
       expect(yeomanUi["startWatch"](targetPath, targetMap)).to.not.empty;
       callBack("rename", folderPath);
       callBack("rename", subFolderPath);
@@ -215,7 +229,9 @@ describe("yeomanui unit test", () => {
     it("startWatch, 'change' event skipped", () => {
       const targetPath = path.join("/", "targetRoot");
       const folderPath = path.join("testPath");
-      stubStat.withArgs(path.join(targetPath, folderPath)).returns({ isDirectory: () => true });
+      stubStat
+        .withArgs(path.join(targetPath, folderPath))
+        .returns({ isDirectory: () => true });
       expect(yeomanUi["startWatch"](targetPath, targetMap)).to.not.empty;
       callBack("change", folderPath);
       expect(targetMap.size).to.equal(0);
@@ -224,7 +240,9 @@ describe("yeomanui unit test", () => {
     it("startWatch, 'statSync' throws exception", () => {
       const targetPath = path.join("/", "targetRoot");
       const folderPath = path.join("testPath");
-      stubStat.withArgs(path.join(targetPath, folderPath)).throws("statSync error");
+      stubStat
+        .withArgs(path.join(targetPath, folderPath))
+        .throws("statSync error");
       expect(yeomanUi["startWatch"](targetPath, targetMap)).to.not.empty;
       callBack("rename", folderPath);
       expect(targetMap.size).to.equal(0);
@@ -284,11 +302,15 @@ describe("yeomanui unit test", () => {
 
     beforeEach(() => {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      sandbox.stub(fs, "watch").value((p: string, o: any, cb: (event: string, file: string) => void) => {
-        return {
-          close: () => {},
-        };
-      });
+      sandbox
+        .stub(fs, "watch")
+        .value(
+          (p: string, o: any, cb: (event: string, file: string) => void) => {
+            return {
+              close: () => { },
+            };
+          }
+        );
     });
 
     it("flow is successfull", async () => {
@@ -307,13 +329,35 @@ describe("yeomanui unit test", () => {
           },
         });
       youiEventsMock.expects("setAppWizardHeaderTitle").withArgs(undefined);
-      wsConfigMock.expects("get").withExactArgs("ApplicationWizard.TargetFolder").twice();
-      wsConfigMock.expects("get").withExactArgs("ApplicationWizard.HideGenerator").once().returns("");
-      rpcMock.expects("invoke").withArgs("showPrompt").resolves({ generator: "test1-project:app" });
-      rpcMock.expects("invoke").withExactArgs("setGenInWriting", [false]).resolves();
-      trackerWrapperMock.expects("updateGeneratorStarted").once().returns(undefined);
-      trackerWrapperMock.expects("updateGeneratorSelected").withArgs("test1-project:app").returns(undefined);
-      trackerWrapperMock.expects("updateGeneratorEnded").once().returns(undefined);
+      wsConfigMock
+        .expects("get")
+        .withExactArgs("ApplicationWizard.TargetFolder")
+        .twice();
+      wsConfigMock
+        .expects("get")
+        .withExactArgs("ApplicationWizard.HideGenerator")
+        .once()
+        .returns("");
+      rpcMock
+        .expects("invoke")
+        .withArgs("showPrompt")
+        .resolves({ generator: "test1-project:app" });
+      rpcMock
+        .expects("invoke")
+        .withExactArgs("setGenInWriting", [false])
+        .resolves();
+      trackerWrapperMock
+        .expects("updateGeneratorStarted")
+        .once()
+        .returns(undefined);
+      trackerWrapperMock
+        .expects("updateGeneratorSelected")
+        .withArgs("test1-project:app")
+        .returns(undefined);
+      trackerWrapperMock
+        .expects("updateGeneratorEnded")
+        .once()
+        .returns(undefined);
       await yeomanUi["receiveIsWebviewReady"]();
     });
 
@@ -339,9 +383,18 @@ describe("yeomanui unit test", () => {
             on: () => "",
           },
         });
-      wsConfigMock.expects("get").withExactArgs(yeomanUi["TARGET_FOLDER_CONFIG_PROP"]).twice();
-      rpcMock.expects("invoke").withExactArgs("setGenInWriting", [false]).resolves();
-      trackerWrapperMock.expects("updateGeneratorSelected").withArgs("test4:app").resolves();
+      wsConfigMock
+        .expects("get")
+        .withExactArgs(yeomanUi["TARGET_FOLDER_CONFIG_PROP"])
+        .twice();
+      rpcMock
+        .expects("invoke")
+        .withExactArgs("setGenInWriting", [false])
+        .resolves();
+      trackerWrapperMock
+        .expects("updateGeneratorSelected")
+        .withArgs("test4:app")
+        .resolves();
       trackerWrapperMock.expects("updateGeneratorEnded").once().resolves();
       await yeomanUi["receiveIsWebviewReady"]();
     });
@@ -356,7 +409,9 @@ describe("yeomanui unit test", () => {
     it("called with command id & args", () => {
       const commandId = "vscode.open";
       const commandArgs = [{ fsPath: "https://en.wikipedia.org" }];
-      youiEventsMock.expects("executeCommand").withExactArgs(commandId, commandArgs);
+      youiEventsMock
+        .expects("executeCommand")
+        .withExactArgs(commandId, commandArgs);
       yeomanUi["executeCommand"](commandId, ...commandArgs);
     });
   });
@@ -381,13 +436,19 @@ describe("yeomanui unit test", () => {
 
   it("_notifyGeneratorsChange", async () => {
     envUtilsMock.expects("getGeneratorsData").resolves();
-    wsConfigMock.expects("get").withExactArgs("ApplicationWizard.HideGenerator").returns("");
+    wsConfigMock
+      .expects("get")
+      .withExactArgs("ApplicationWizard.HideGenerator")
+      .returns("");
     rpcMock.expects("invoke").withArgs("updateGeneratorsPrompt");
     await yeomanUi._notifyGeneratorsChange();
   });
 
   it("running generator throws error and watcher does not exist", async () => {
-    wsConfigMock.expects("get").withExactArgs("ApplicationWizard.TargetFolder").throws("get error");
+    wsConfigMock
+      .expects("get")
+      .withExactArgs("ApplicationWizard.TargetFolder")
+      .throws("get error");
     sandbox.stub(yeomanUi as any, "onGeneratorFailure").returns({});
     await yeomanUi["runGenerator"]("test1-project:app");
   });
@@ -400,11 +461,20 @@ describe("yeomanui unit test", () => {
     });
     it("called with empty args array (install ended) and the prompt is generators", async () => {
       const args: any = [];
-      const rpcInvokeStub = sandbox.stub(rpc, "invoke").onFirstCall().resolves(true).onSecondCall().resolves();
+      const rpcInvokeStub = sandbox
+        .stub(rpc, "invoke")
+        .onFirstCall()
+        .resolves(true)
+        .onSecondCall()
+        .resolves();
       await yeomanUi._notifyGeneratorsInstall(args, false);
       expect(rpcInvokeStub.callCount).to.equal(2);
-      expect(rpcInvokeStub.firstCall.args).to.deep.equal(["isGeneratorsPrompt"]);
-      expect(rpcInvokeStub.secondCall.args).to.deep.equal(["resetPromptMessage"]);
+      expect(rpcInvokeStub.firstCall.args).to.deep.equal([
+        "isGeneratorsPrompt",
+      ]);
+      expect(rpcInvokeStub.secondCall.args).to.deep.equal([
+        "resetPromptMessage",
+      ]);
       expect(yeomanUi["uiOptions"].installGens).to.be.undefined;
       rpcInvokeStub.restore();
     });
@@ -423,11 +493,17 @@ describe("yeomanui unit test", () => {
           versionRange: "^2.0.1",
         },
       ];
-      rpcMock.expects("invoke").withExactArgs("isGeneratorsPrompt").resolves(true);
+      rpcMock
+        .expects("invoke")
+        .withExactArgs("isGeneratorsPrompt")
+        .resolves(true);
       youiEventsMock.expects("getAppWizard").returns(appWizard);
       appWizardMock
         .expects("showWarning")
-        .withExactArgs(yeomanUi["uiOptions"].messages.generators_are_being_installed, MessageType.prompt);
+        .withExactArgs(
+          yeomanUi["uiOptions"].messages.generators_are_being_installed,
+          MessageType.prompt
+        );
       appWizardMock.expects("showInformation").never();
       await yeomanUi._notifyGeneratorsInstall(args, false);
       expect(yeomanUi["uiOptions"].installGens).to.be.deep.equal(args);
@@ -447,11 +523,17 @@ describe("yeomanui unit test", () => {
           versionRange: "^2.0.1",
         },
       ];
-      rpcMock.expects("invoke").withExactArgs("isGeneratorsPrompt").resolves(false);
+      rpcMock
+        .expects("invoke")
+        .withExactArgs("isGeneratorsPrompt")
+        .resolves(false);
       youiEventsMock.expects("getAppWizard").returns(appWizard);
       appWizardMock
         .expects("showWarning")
-        .withExactArgs(yeomanUi["uiOptions"].messages.generators_are_being_installed, MessageType.prompt);
+        .withExactArgs(
+          yeomanUi["uiOptions"].messages.generators_are_being_installed,
+          MessageType.prompt
+        );
       appWizardMock.expects("showInformation").never();
       await yeomanUi._notifyGeneratorsInstall(args, true);
       expect(yeomanUi["uiOptions"].installGens).to.be.deep.equal(args);
@@ -471,7 +553,10 @@ describe("yeomanui unit test", () => {
           versionRange: "^2.0.1",
         },
       ];
-      rpcMock.expects("invoke").withExactArgs("isGeneratorsPrompt").resolves(false);
+      rpcMock
+        .expects("invoke")
+        .withExactArgs("isGeneratorsPrompt")
+        .resolves(false);
       youiEventsMock.expects("getAppWizard").never();
       appWizardMock.expects("showInformation").never();
       await yeomanUi._notifyGeneratorsInstall(args, false);
@@ -481,19 +566,31 @@ describe("yeomanui unit test", () => {
 
   describe("showGeneratorsInstallingMessage", () => {
     it("called with empty args array (install ended)", async () => {
-      const rpcInvokeStub = sandbox.stub(rpc, "invoke").onFirstCall().resolves(true).onSecondCall().resolves();
+      const rpcInvokeStub = sandbox
+        .stub(rpc, "invoke")
+        .onFirstCall()
+        .resolves(true)
+        .onSecondCall()
+        .resolves();
       appWizardMock.expects("showWarning").never();
       await yeomanUi._notifyGeneratorsInstall([], false);
       expect(rpcInvokeStub.callCount).to.equal(2);
-      expect(rpcInvokeStub.firstCall.args).to.deep.equal(["isGeneratorsPrompt"]);
-      expect(rpcInvokeStub.secondCall.args).to.deep.equal(["resetPromptMessage"]);
+      expect(rpcInvokeStub.firstCall.args).to.deep.equal([
+        "isGeneratorsPrompt",
+      ]);
+      expect(rpcInvokeStub.secondCall.args).to.deep.equal([
+        "resetPromptMessage",
+      ]);
       rpcInvokeStub.restore();
     });
     it("called with args array containing generators (install started)", () => {
       youiEventsMock.expects("getAppWizard").returns(appWizard);
       appWizardMock
         .expects("showWarning")
-        .withExactArgs(yeomanUi["uiOptions"].messages.generators_are_being_installed, MessageType.prompt);
+        .withExactArgs(
+          yeomanUi["uiOptions"].messages.generators_are_being_installed,
+          MessageType.prompt
+        );
       appWizardMock.expects("showInformation").never();
       void yeomanUi._notifyGeneratorsInstall([{}], true);
     });
@@ -555,13 +652,16 @@ describe("yeomanui unit test", () => {
           generatorPackageJson: {
             description: "test5Description",
           },
-        },
+        }
       ];
     });
 
     it("there are no generators", async () => {
       envUtilsMock.expects("getGeneratorsData").withExactArgs().resolves([]);
-      wsConfigMock.expects("get").withExactArgs("ApplicationWizard.HideGenerator").returns("");
+      wsConfigMock
+        .expects("get")
+        .withExactArgs("ApplicationWizard.HideGenerator")
+        .returns("");
       const result = await yeomanUi["getGeneratorsPrompt"]();
       const generatorQuestion: any = {
         type: "list",
@@ -587,7 +687,7 @@ describe("yeomanui unit test", () => {
         outputChannel,
         testLogger,
         { filter: GeneratorFilter.create(), messages },
-        flowPromise.state,
+        flowPromise.state
       );
       const noGeneratorsResult = {
         name: "Select Generator",
@@ -597,7 +697,8 @@ describe("yeomanui unit test", () => {
             guiType: "tiles",
             guiOptions: {
               breadcrumb: "",
-              hint: yeomanUi["uiOptions"].messages.select_generator_question_hint,
+              hint: yeomanUi["uiOptions"].messages
+                .select_generator_question_hint,
             },
             name: "generator",
             message: yeomanUi["uiOptions"].messages.channel_name,
@@ -619,8 +720,14 @@ describe("yeomanui unit test", () => {
             description: "test hidden category",
           },
         };
-        envUtilsMock.expects("getGeneratorsData").withExactArgs().resolves([generatorData]);
-        wsConfigMock.expects("get").withExactArgs("ApplicationWizard.HideGenerator").returns("");
+        envUtilsMock
+          .expects("getGeneratorsData")
+          .withExactArgs()
+          .resolves([generatorData]);
+        wsConfigMock
+          .expects("get")
+          .withExactArgs("ApplicationWizard.HideGenerator")
+          .returns("");
         const result = await yeomanUiInstance["getGeneratorsPrompt"]();
         expect(result).to.be.deep.equal(noGeneratorsResult);
         expect(result.questions[0].choices).to.be.empty;
@@ -642,7 +749,10 @@ describe("yeomanui unit test", () => {
           .expects("get")
           .withExactArgs("ApplicationWizard.HideGenerator")
           .returns("@ns/test1-project ,  other:app ");
-        envUtilsMock.expects("getGeneratorsData").withExactArgs().resolves([generatorData]);
+        envUtilsMock
+          .expects("getGeneratorsData")
+          .withExactArgs()
+          .resolves([generatorData]);
         const result = await yeomanUiInstance["getGeneratorsPrompt"]();
         expect(result).to.be.deep.equal(noGeneratorsResult);
         expect(result.questions[0].choices).to.be.empty;
@@ -652,12 +762,20 @@ describe("yeomanui unit test", () => {
         const generatorData = {
           generatorMeta,
           generatorPackageJson: {
-            "generator-filter": { categories: ["sap.cap", "hidden", "some.category"] },
+            "generator-filter": {
+              categories: ["sap.cap", "hidden", "some.category"],
+            },
             description: "test hidden category",
           },
         };
-        envUtilsMock.expects("getGeneratorsData").withExactArgs().resolves([generatorData]);
-        wsConfigMock.expects("get").withExactArgs("ApplicationWizard.HideGenerator").returns("");
+        envUtilsMock
+          .expects("getGeneratorsData")
+          .withExactArgs()
+          .resolves([generatorData]);
+        wsConfigMock
+          .expects("get")
+          .withExactArgs("ApplicationWizard.HideGenerator")
+          .returns("");
         const result = await yeomanUiInstance["getGeneratorsPrompt"]();
         expect(result).to.be.deep.equal(noGeneratorsResult);
         expect(result.questions[0].choices).to.be.empty;
@@ -672,8 +790,14 @@ describe("yeomanui unit test", () => {
             description,
           },
         };
-        envUtilsMock.expects("getGeneratorsData").withExactArgs().resolves([generatorData]);
-        wsConfigMock.expects("get").withExactArgs("ApplicationWizard.HideGenerator").returns("");
+        envUtilsMock
+          .expects("getGeneratorsData")
+          .withExactArgs()
+          .resolves([generatorData]);
+        wsConfigMock
+          .expects("get")
+          .withExactArgs("ApplicationWizard.HideGenerator")
+          .returns("");
         const result = await yeomanUiInstance["getGeneratorsPrompt"]();
         expect(result.questions[0].choices).to.have.lengthOf(1);
         const test1Choice = result.questions[0].choices[0];
@@ -683,17 +807,31 @@ describe("yeomanui unit test", () => {
     });
 
     it("get generators with type project", async () => {
-      wsConfigMock.expects("get").withExactArgs("ApplicationWizard.Workspace").returns({});
-      wsConfigMock.expects("get").withExactArgs("ApplicationWizard.HideGenerator").once().returns("");
-      envUtilsMock.expects("getGeneratorsData").withExactArgs().resolves(gensMeta);
-      wsConfigMock.expects("get").withExactArgs(yeomanUi["TARGET_FOLDER_CONFIG_PROP"]);
+      wsConfigMock
+        .expects("get")
+        .withExactArgs("ApplicationWizard.Workspace")
+        .returns({});
+      wsConfigMock
+        .expects("get")
+        .withExactArgs("ApplicationWizard.HideGenerator")
+        .once()
+        .returns("");
+      envUtilsMock
+        .expects("getGeneratorsData")
+        .withExactArgs()
+        .resolves(gensMeta);
+      wsConfigMock
+        .expects("get")
+        .withExactArgs(yeomanUi["TARGET_FOLDER_CONFIG_PROP"]);
       const genFilter: GeneratorFilter = GeneratorFilter.create({
         type: "project",
       });
       yeomanUi["uiOptions"] = { filter: genFilter, messages };
       const result: any = await yeomanUi["getGeneratorsPrompt"]();
 
-      const question = result.questions.find((question: { type: string }) => question.type === "list");
+      const question = result.questions.find(
+        (question: { type: string }) => question.type === "list"
+      );
       expect(question.choices).to.have.lengthOf(2);
       const test1Choice = question.choices[0];
       const test2Choice = question.choices[1];
@@ -704,8 +842,14 @@ describe("yeomanui unit test", () => {
     });
 
     it("get generators with type module", async () => {
-      envUtilsMock.expects("getGeneratorsData").withExactArgs().resolves(gensMeta);
-      wsConfigMock.expects("get").withExactArgs("ApplicationWizard.HideGenerator").returns("");
+      envUtilsMock
+        .expects("getGeneratorsData")
+        .withExactArgs()
+        .resolves(gensMeta);
+      wsConfigMock
+        .expects("get")
+        .withExactArgs("ApplicationWizard.HideGenerator")
+        .returns("");
       const genFilter = GeneratorFilter.create({ type: "module" });
       yeomanUi["uiOptions"] = { filter: genFilter, messages };
       const result = await yeomanUi["getGeneratorsPrompt"]();
@@ -718,7 +862,91 @@ describe("yeomanui unit test", () => {
 
     it("get generators all generators", async () => {
       envUtilsMock.expects("getGeneratorsData").resolves(gensMeta);
-      wsConfigMock.expects("get").withExactArgs("ApplicationWizard.HideGenerator").returns("");
+      wsConfigMock
+        .expects("get")
+        .withExactArgs("ApplicationWizard.HideGenerator")
+        .returns("");
+      yeomanUi["uiOptions"] = {
+        filter: GeneratorFilter.create({ type: [] }),
+        messages,
+      };
+      const result = await yeomanUi["getGeneratorsPrompt"]();
+
+      expect(result.questions[0].choices).to.have.lengthOf(5);
+    });
+
+    it("get generators all generators and additional generators", async () => {
+      const gensMeta = [
+        {
+          generatorMeta: {
+            generatorPath: "test1Path/app/index.js",
+            namespace: "test1-project:app",
+            packagePath: "test1Path",
+          },
+          generatorPackageJson: {
+            "generator-filter": { type: "project" },
+            description: "test1Description",
+          },
+        },
+        {
+          generatorMeta: {
+            generatorPath: "test2Path/app/index.js",
+            namespace: "test2-module:app",
+            packagePath: "test2Path",
+          },
+          generatorPackageJson: {
+            "generator-filter": { type: "project_test" },
+          },
+        },
+        {
+          generatorMeta: {
+            generatorPath: "test3Path/app/index.js",
+            namespace: "test3:app",
+            packagePath: "test3Path",
+          },
+          generatorPackageJson: {
+            "generator-filter": { type: "module" },
+          },
+        },
+        {
+          generatorMeta: {
+            generatorPath: "test4Path/app/index.js",
+            namespace: "test4:app",
+            packagePath: "test4Path",
+          },
+          generatorPackageJson: {
+            "generator-filter": { type: "project" },
+            description: "test4Description",
+            additional_generators: [{
+              namespace: "test4:subgen",
+              description: "test 4 sub gen description",
+              displayName: "Test Sub Gen 4"
+            }]
+          },
+        },
+        {
+          generatorMeta: {
+            generatorPath: "test4Path/subgen/index.js",
+            namespace: "test4:subgen",
+            packagePath: "test4Path",
+            isAdditional: true
+          },
+          generatorPackageJson: {
+            description: "test5Description",
+            additional_generators: [{
+              namespace: "test4:subgen",
+              description: "test 4 sub gen description",
+              displayName: "Test Sub Gen 4"
+            }]
+          },
+        }
+      ];
+
+      envUtilsMock.expects("getGeneratorsData").resolves(gensMeta);
+      wsConfigMock
+        .expects("get")
+        .withExactArgs("ApplicationWizard.HideGenerator")
+        .returns("");
       yeomanUi["uiOptions"] = {
         filter: GeneratorFilter.create({ type: [] }),
         messages,
@@ -729,8 +957,14 @@ describe("yeomanui unit test", () => {
     });
 
     it("wrong generators filter type is provided", async () => {
-      wsConfigMock.expects("get").withExactArgs("ApplicationWizard.Workspace").returns({});
-      wsConfigMock.expects("get").withExactArgs("ApplicationWizard.HideGenerator").returns("");
+      wsConfigMock
+        .expects("get")
+        .withExactArgs("ApplicationWizard.Workspace")
+        .returns({});
+      wsConfigMock
+        .expects("get")
+        .withExactArgs("ApplicationWizard.HideGenerator")
+        .returns("");
       envUtilsMock
         .expects("getGeneratorsData")
         .withExactArgs()
@@ -748,20 +982,30 @@ describe("yeomanui unit test", () => {
           },
         ]);
 
-      wsConfigMock.expects("get").withExactArgs(yeomanUi["TARGET_FOLDER_CONFIG_PROP"]);
+      wsConfigMock
+        .expects("get")
+        .withExactArgs(yeomanUi["TARGET_FOLDER_CONFIG_PROP"]);
       yeomanUi["uiOptions"] = {
         filter: GeneratorFilter.create({ type: "project" }),
         messages,
       };
       const result = await yeomanUi["getGeneratorsPrompt"]();
 
-      const question = result.questions.find((question: { type: string }) => question.type === "list");
+      const question = result.questions.find(
+        (question: { type: string }) => question.type === "list"
+      );
       expect(question.choices).to.be.empty;
     });
 
     it("get generators with type project and categories cat1 and cat2", async () => {
-      wsConfigMock.expects("get").withExactArgs("ApplicationWizard.Workspace").returns({});
-      wsConfigMock.expects("get").withExactArgs("ApplicationWizard.HideGenerator").returns("");
+      wsConfigMock
+        .expects("get")
+        .withExactArgs("ApplicationWizard.Workspace")
+        .returns({});
+      wsConfigMock
+        .expects("get")
+        .withExactArgs("ApplicationWizard.HideGenerator")
+        .returns("");
       gensMeta[0].generatorPackageJson = {
         "generator-filter": { type: ["project"], categories: ["cat2"] },
         description: "test1Description",
@@ -776,17 +1020,24 @@ describe("yeomanui unit test", () => {
         "generator-filter": { type: "project", categories: ["cat1"] },
         description: "test4Description",
       };
-      envUtilsMock.expects("getGeneratorsData").withExactArgs().resolves(gensMeta);
+      envUtilsMock
+        .expects("getGeneratorsData")
+        .withExactArgs()
+        .resolves(gensMeta);
 
       const genFilter: GeneratorFilter = GeneratorFilter.create({
         type: ["project"],
         categories: ["cat1", "cat2"],
       });
       yeomanUi["uiOptions"].filter = genFilter;
-      wsConfigMock.expects("get").withExactArgs(yeomanUi["TARGET_FOLDER_CONFIG_PROP"]);
+      wsConfigMock
+        .expects("get")
+        .withExactArgs(yeomanUi["TARGET_FOLDER_CONFIG_PROP"]);
       const result = await yeomanUi["getGeneratorsPrompt"]();
 
-      const question = result.questions.find((question: { type: string }) => question.type === "list");
+      const question = result.questions.find(
+        (question: { type: string }) => question.type === "list"
+      );
       expect(question.choices).to.have.lengthOf(3);
       const test1Choice = question.choices[0];
       const test2Choice = question.choices[1];
@@ -801,8 +1052,14 @@ describe("yeomanui unit test", () => {
         description: "test3Description",
         displayName: "3rd - Test",
       };
-      envUtilsMock.expects("getGeneratorsData").withExactArgs().resolves(gensMeta.slice(0, 3));
-      wsConfigMock.expects("get").withExactArgs("ApplicationWizard.HideGenerator").returns("");
+      envUtilsMock
+        .expects("getGeneratorsData")
+        .withExactArgs()
+        .resolves(gensMeta.slice(0, 3));
+      wsConfigMock
+        .expects("get")
+        .withExactArgs("ApplicationWizard.HideGenerator")
+        .returns("");
 
       yeomanUi["uiOptions"] = {
         filter: GeneratorFilter.create({ type: undefined }),
@@ -832,8 +1089,14 @@ describe("yeomanui unit test", () => {
         homepage: "https://myhomepage.com/ANY/generator-test2-module#readme",
       };
 
-      envUtilsMock.expects("getGeneratorsData").withExactArgs().resolves(gensMeta.slice(0, 3));
-      wsConfigMock.expects("get").withExactArgs("ApplicationWizard.HideGenerator").returns("");
+      envUtilsMock
+        .expects("getGeneratorsData")
+        .withExactArgs()
+        .resolves(gensMeta.slice(0, 3));
+      wsConfigMock
+        .expects("get")
+        .withExactArgs("ApplicationWizard.HideGenerator")
+        .returns("");
 
       yeomanUi["uiOptions"] = { filter: GeneratorFilter.create(), messages };
       const result = await yeomanUi["getGeneratorsPrompt"]();
@@ -843,24 +1106,40 @@ describe("yeomanui unit test", () => {
       const test1Choice = choices[0];
       const test2Choice = choices[1];
       const test3Choice = choices[2];
-      expect(test1Choice.homepage).to.be.equal("https://myhomepage.com/ANY/generator-test1-project#readme");
-      expect(test2Choice.homepage).to.be.equal("https://myhomepage.com/ANY/generator-test2-module#readme");
+      expect(test1Choice.homepage).to.be.equal(
+        "https://myhomepage.com/ANY/generator-test1-project#readme"
+      );
+      expect(test2Choice.homepage).to.be.equal(
+        "https://myhomepage.com/ANY/generator-test2-module#readme"
+      );
       expect(test3Choice.homepage).to.be.equal("");
     });
 
     it("generator with type project", async () => {
-      envUtilsMock.expects("getGeneratorsData").withExactArgs().resolves(gensMeta.slice(0, 1));
+      envUtilsMock
+        .expects("getGeneratorsData")
+        .withExactArgs()
+        .resolves(gensMeta.slice(0, 1));
       sandbox
         .stub(vscode.workspace, "workspaceFolders")
-        .value([{ uri: { fsPath: "rootFolderPath" } }, { uri: { fsPath: "testRoot" } }]);
+        .value([
+          { uri: { fsPath: "rootFolderPath" } },
+          { uri: { fsPath: "testRoot" } },
+        ]);
 
       yeomanUi["uiOptions"] = {
         filter: GeneratorFilter.create({ type: "project" }),
         messages,
       };
-      wsConfigMock.expects("get").withExactArgs(yeomanUi["TARGET_FOLDER_CONFIG_PROP"]);
-      wsConfigMock.expects("get").withExactArgs(yeomanUi["SELECTED_WORKSPACE_CONFIG_PROP"]);
-      wsConfigMock.expects("get").withExactArgs(yeomanUi["HIDE_GENERATORS_PROP"]);
+      wsConfigMock
+        .expects("get")
+        .withExactArgs(yeomanUi["TARGET_FOLDER_CONFIG_PROP"]);
+      wsConfigMock
+        .expects("get")
+        .withExactArgs(yeomanUi["SELECTED_WORKSPACE_CONFIG_PROP"]);
+      wsConfigMock
+        .expects("get")
+        .withExactArgs(yeomanUi["HIDE_GENERATORS_PROP"]);
 
       await yeomanUi["getGeneratorsPrompt"]();
     });
@@ -870,19 +1149,34 @@ describe("yeomanui unit test", () => {
         "generator-filter": { type: "tools-suite" },
         description: "test4Description",
       };
-      envUtilsMock.expects("getGeneratorsData").withExactArgs().resolves(gensMeta.slice(0, 1));
+      envUtilsMock
+        .expects("getGeneratorsData")
+        .withExactArgs()
+        .resolves(gensMeta.slice(0, 1));
       sandbox
         .stub(vscode.workspace, "workspaceFolders")
-        .value([{ uri: { fsPath: "rootFolderPath" } }, { uri: { fsPath: "testRoot" } }]);
-      wsConfigMock.expects("get").withExactArgs(yeomanUi["TARGET_FOLDER_CONFIG_PROP"]);
-      wsConfigMock.expects("get").withExactArgs(yeomanUi["SELECTED_WORKSPACE_CONFIG_PROP"]);
-      wsConfigMock.expects("get").withExactArgs("ApplicationWizard.HideGenerator").returns("gen1,gen2,gen3");
+        .value([
+          { uri: { fsPath: "rootFolderPath" } },
+          { uri: { fsPath: "testRoot" } },
+        ]);
+      wsConfigMock
+        .expects("get")
+        .withExactArgs(yeomanUi["TARGET_FOLDER_CONFIG_PROP"]);
+      wsConfigMock
+        .expects("get")
+        .withExactArgs(yeomanUi["SELECTED_WORKSPACE_CONFIG_PROP"]);
+      wsConfigMock
+        .expects("get")
+        .withExactArgs("ApplicationWizard.HideGenerator")
+        .returns("gen1,gen2,gen3");
       yeomanUi["uiOptions"] = {
         filter: GeneratorFilter.create({ type: "project" }),
         messages,
       };
       await yeomanUi["getGeneratorsPrompt"]();
-      expect(yeomanUi["generatorsToIgnoreArray"]).to.be.contains("test1-project:app");
+      expect(yeomanUi["generatorsToIgnoreArray"]).to.be.contains(
+        "test1-project:app"
+      );
     });
   });
 
@@ -901,12 +1195,21 @@ describe("yeomanui unit test", () => {
   });
 
   describe("getCwd", () => {
-    const yeomanUiInstance: YeomanUI = new YeomanUI(rpc, youiEvents, outputChannel, testLogger, {}, flowPromise.state);
+    const yeomanUiInstance: YeomanUI = new YeomanUI(
+      rpc,
+      youiEvents,
+      outputChannel,
+      testLogger,
+      {},
+      flowPromise.state
+    );
 
     it("in VSCODE, target folder is undefined", () => {
       Constants.IS_IN_BAS = false;
       _.set(vscode, "workspace.workspaceFolders[0].uri.fsPath", undefined);
-      wsConfigMock.expects("get").withExactArgs(yeomanUiInstance["TARGET_FOLDER_CONFIG_PROP"]);
+      wsConfigMock
+        .expects("get")
+        .withExactArgs(yeomanUiInstance["TARGET_FOLDER_CONFIG_PROP"]);
       const res = yeomanUiInstance["getCwd"]();
       expect(res).equal(Constants.HOMEDIR_PROJECTS);
     });
@@ -914,7 +1217,10 @@ describe("yeomanui unit test", () => {
     it("in VSCODE, target folder is empty non-zero length string", () => {
       Constants.IS_IN_BAS = false;
       _.set(vscode, "workspace.workspaceFolders[0].uri.fsPath", undefined);
-      wsConfigMock.expects("get").withExactArgs(yeomanUiInstance["TARGET_FOLDER_CONFIG_PROP"]).returns("     ");
+      wsConfigMock
+        .expects("get")
+        .withExactArgs(yeomanUiInstance["TARGET_FOLDER_CONFIG_PROP"])
+        .returns("     ");
       const res = yeomanUiInstance["getCwd"]();
       expect(res).equal(Constants.HOMEDIR_PROJECTS);
     });
@@ -934,8 +1240,14 @@ describe("yeomanui unit test", () => {
     it("in VSCODE, a folder is opened", () => {
       Constants.IS_IN_BAS = false;
       const openedVscodeFolderPath = "/home/user/folder/folder2";
-      _.set(vscode, "workspace.workspaceFolders[0].uri.fsPath", openedVscodeFolderPath);
-      wsConfigMock.expects("get").withExactArgs(yeomanUiInstance["TARGET_FOLDER_CONFIG_PROP"]);
+      _.set(
+        vscode,
+        "workspace.workspaceFolders[0].uri.fsPath",
+        openedVscodeFolderPath
+      );
+      wsConfigMock
+        .expects("get")
+        .withExactArgs(yeomanUiInstance["TARGET_FOLDER_CONFIG_PROP"]);
       const res = yeomanUiInstance["getCwd"]();
       expect(res).equal(openedVscodeFolderPath);
     });
@@ -943,7 +1255,9 @@ describe("yeomanui unit test", () => {
     it("in BAS, target folder is undefined", () => {
       Constants.IS_IN_BAS = true;
       _.set(vscode, "workspace.workspaceFolders[0].uri.fsPath", undefined);
-      wsConfigMock.expects("get").withExactArgs(yeomanUiInstance["TARGET_FOLDER_CONFIG_PROP"]);
+      wsConfigMock
+        .expects("get")
+        .withExactArgs(yeomanUiInstance["TARGET_FOLDER_CONFIG_PROP"]);
       const res = yeomanUiInstance["getCwd"]();
       expect(res).equal(Constants.HOMEDIR_PROJECTS);
     });
@@ -951,7 +1265,10 @@ describe("yeomanui unit test", () => {
     it("in BAS, target folder is empty non-zero length string", () => {
       Constants.IS_IN_BAS = true;
       _.set(vscode, "workspace.workspaceFolders[0].uri.fsPath", undefined);
-      wsConfigMock.expects("get").withExactArgs(yeomanUiInstance["TARGET_FOLDER_CONFIG_PROP"]).returns("     ");
+      wsConfigMock
+        .expects("get")
+        .withExactArgs(yeomanUiInstance["TARGET_FOLDER_CONFIG_PROP"])
+        .returns("     ");
       const res = yeomanUiInstance["getCwd"]();
       expect(res).equal(Constants.HOMEDIR_PROJECTS);
     });
@@ -976,7 +1293,7 @@ describe("yeomanui unit test", () => {
       outputChannel,
       testLogger,
       null,
-      flowPromise.state,
+      flowPromise.state
     );
     const errorInfo = "Error Info";
     const res = yeomanUiInstance["getErrorInfo"](errorInfo);
@@ -985,7 +1302,11 @@ describe("yeomanui unit test", () => {
 
   describe("answersUtils", () => {
     it("setDefaults", () => {
-      const questions = [{ name: "q1", default: "a" }, { name: "q2", default: () => "b" }, { name: "q3" }];
+      const questions = [
+        { name: "q1", default: "a" },
+        { name: "q2", default: () => "b" },
+        { name: "q3" },
+      ];
       const answers = {
         q1: "x",
         q2: "y",
@@ -993,13 +1314,19 @@ describe("yeomanui unit test", () => {
       };
       ReplayUtils["setDefaults"](questions, answers);
       for (const question of questions) {
-        expect((question as any)["__origAnswer"]).to.equal((<any>answers)[question.name]);
+        expect((question as any)["__origAnswer"]).to.equal(
+          (<any>answers)[question.name]
+        );
         expect((question as any)["__ForceDefault"]).to.be.true;
       }
     });
 
     it("setDefaults", () => {
-      const questions = [{ name: "q1", default: "a" }, { name: "q2", default: () => "b" }, { name: "q3" }];
+      const questions = [
+        { name: "q1", default: "a" },
+        { name: "q2", default: () => "b" },
+        { name: "q3" },
+      ];
       const answers = {
         q1: "x",
         q3: "z",
@@ -1012,7 +1339,14 @@ describe("yeomanui unit test", () => {
   });
 
   it("handleErrors", () => {
-    const yeomanUiInstance: YeomanUI = new YeomanUI(rpc, youiEvents, outputChannel, testLogger, {}, flowPromise.state);
+    const yeomanUiInstance: YeomanUI = new YeomanUI(
+      rpc,
+      youiEvents,
+      outputChannel,
+      testLogger,
+      {},
+      flowPromise.state
+    );
     const env: Environment = Environment.createEnv();
     const envMock = sandbox.mock(env);
     const gen = { on: () => "" };
@@ -1029,7 +1363,14 @@ describe("yeomanui unit test", () => {
   });
 
   it("handleErrors - when 'startOver' operation selected", () => {
-    const yeomanUiInstance: YeomanUI = new YeomanUI(rpc, youiEvents, outputChannel, testLogger, {}, flowPromise.state);
+    const yeomanUiInstance: YeomanUI = new YeomanUI(
+      rpc,
+      youiEvents,
+      outputChannel,
+      testLogger,
+      {},
+      flowPromise.state
+    );
     yeomanUiInstance["onUncaughtException"] = () => "";
     const onUncaughtExceptionBefore = yeomanUiInstance["onUncaughtException"];
     const env: Environment = Environment.createEnv();
@@ -1040,19 +1381,30 @@ describe("yeomanui unit test", () => {
     envMock.expects("on").withArgs("error");
     genMock.expects("on").withArgs("error");
     processMock.expects("on").withArgs("uncaughtException");
-    processMock.expects("removeListener").withArgs("uncaughtException", onUncaughtExceptionBefore);
+    processMock
+      .expects("removeListener")
+      .withArgs("uncaughtException", onUncaughtExceptionBefore);
     yeomanUiInstance["handleErrors"](env, gen, "genName");
     envMock.verify();
     genMock.verify();
     processMock.verify();
     expect(yeomanUiInstance["onUncaughtException"]).to.be.ok;
-    expect(yeomanUiInstance["onUncaughtException"]).to.not.equal(onUncaughtExceptionBefore);
+    expect(yeomanUiInstance["onUncaughtException"]).to.not.equal(
+      onUncaughtExceptionBefore
+    );
   });
 
   describe("setGenInWriting", () => {
     let genMock: any;
     let rpcMock: any;
-    const yeomanUiInstance: YeomanUI = new YeomanUI(rpc, youiEvents, outputChannel, testLogger, {}, flowPromise.state);
+    const yeomanUiInstance: YeomanUI = new YeomanUI(
+      rpc,
+      youiEvents,
+      outputChannel,
+      testLogger,
+      {},
+      flowPromise.state
+    );
     const gen: any = { on: () => "" };
 
     beforeEach(() => {
@@ -1078,8 +1430,18 @@ describe("yeomanui unit test", () => {
   });
 
   it("exploreGenerators", () => {
-    const yeomanUiInstance: YeomanUI = new YeomanUI(rpc, youiEvents, outputChannel, testLogger, {}, flowPromise.state);
-    commandsMock.expects("executeCommand").withExactArgs("exploreGenerators").resolves();
+    const yeomanUiInstance: YeomanUI = new YeomanUI(
+      rpc,
+      youiEvents,
+      outputChannel,
+      testLogger,
+      {},
+      flowPromise.state
+    );
+    commandsMock
+      .expects("executeCommand")
+      .withExactArgs("exploreGenerators")
+      .resolves();
     yeomanUiInstance["exploreGenerators"]();
   });
 
@@ -1090,7 +1452,7 @@ describe("yeomanui unit test", () => {
       outputChannel,
       testLogger,
       GeneratorFilter.create(),
-      flowPromise.state,
+      flowPromise.state
     );
     const gen: any = { on: () => "" };
     const genMock = sandbox.mock(gen);
@@ -1115,7 +1477,7 @@ describe("yeomanui unit test", () => {
         outputChannel,
         testLogger,
         GeneratorFilter.create(),
-        flowPromise.state,
+        flowPromise.state
       );
       const questions = [{ name: "q1" }];
       const response = await yeomanUiInstance.showPrompt(questions);
@@ -1128,7 +1490,7 @@ describe("yeomanui unit test", () => {
 
       (rpc.invoke as (methodName: string, params: any[]) => Promise<any>) = (
         methodName: string,
-        params: any[],
+        params: any[]
       ): Promise<unknown> => {
         const questionName: string = params[0][0].name;
         if (questionName === "q1") {
@@ -1148,7 +1510,7 @@ describe("yeomanui unit test", () => {
         outputChannel,
         testLogger,
         GeneratorFilter.create(),
-        flowPromise.state,
+        flowPromise.state
       );
       yeomanUiInstance["runGenerator"] = (): Promise<any> => {
         return Promise.resolve();
@@ -1191,22 +1553,31 @@ describe("yeomanui unit test", () => {
       const beforeGen = {
         targetFolderPath: path.join("/", "testDestinationRoot"),
       };
-      changes.set(path.join("/", "testDestinationRoot", "dirpath1"), { isDirectory: true });
+      changes.set(path.join("/", "testDestinationRoot", "dirpath1"), {
+        isDirectory: true,
+      });
       const afterGen = {
         targetFolderPath: path.join("/", "testDestinationRoot"),
         changeMap: changes,
       };
-      trackerWrapperMock.expects("updateGeneratorEnded").withArgs("testGenName").resolves();
+      trackerWrapperMock
+        .expects("updateGeneratorEnded")
+        .withArgs("testGenName")
+        .resolves();
       yeomanUi["onGeneratorSuccess"]("testGenName", beforeGen, afterGen);
       expect(
         doGeneratorDoneSpy.calledWith(
           true,
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          _.get(yeomanUi, "uiOptions.messages.artifact_with_name_generated", (a: string) => "")("testGenName"),
+          _.get(
+            yeomanUi,
+            "uiOptions.messages.artifact_with_name_generated",
+            (a: string) => ""
+          )("testGenName"),
           create_and_close,
           "files",
-          path.join(beforeGen.targetFolderPath, "dirpath1"),
-        ),
+          path.join(beforeGen.targetFolderPath, "dirpath1")
+        )
       ).to.be.true;
     });
 
@@ -1214,23 +1585,34 @@ describe("yeomanui unit test", () => {
       const beforeGen = {
         targetFolderPath: path.join("/", "testDestinationRoot"),
       };
-      changes.set(path.join("/", "testDestinationRoot", "dirpath2"), { isDirectory: true });
-      changes.set(path.join("/", "testDestinationRoot", "dirpath3"), { isDirectory: true });
+      changes.set(path.join("/", "testDestinationRoot", "dirpath2"), {
+        isDirectory: true,
+      });
+      changes.set(path.join("/", "testDestinationRoot", "dirpath3"), {
+        isDirectory: true,
+      });
       const afterGen = {
         targetFolderPath: path.join("/", "testDestinationRoot"),
         changeMap: changes,
       };
-      trackerWrapperMock.expects("updateGeneratorEnded").withArgs("testGenName").resolves();
+      trackerWrapperMock
+        .expects("updateGeneratorEnded")
+        .withArgs("testGenName")
+        .resolves();
       yeomanUi["onGeneratorSuccess"]("testGenName", beforeGen, afterGen);
       expect(
         doGeneratorDoneSpy.calledWith(
           true,
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          _.get(yeomanUi, "uiOptions.messages.artifact_with_name_generated", (a: string) => "")("testGenName"),
+          _.get(
+            yeomanUi,
+            "uiOptions.messages.artifact_with_name_generated",
+            (a: string) => ""
+          )("testGenName"),
           create_and_close,
           "files",
-          null,
-        ),
+          null
+        )
       ).to.be.true;
     });
 
@@ -1242,17 +1624,24 @@ describe("yeomanui unit test", () => {
         targetFolderPath: "testDestinationRoot",
         changeMap: changes,
       };
-      trackerWrapperMock.expects("updateGeneratorEnded").withArgs("testGenName").resolves();
+      trackerWrapperMock
+        .expects("updateGeneratorEnded")
+        .withArgs("testGenName")
+        .resolves();
       yeomanUi["onGeneratorSuccess"]("testGenName", beforeGen, afterGen);
       expect(
         doGeneratorDoneSpy.calledWith(
           true,
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          _.get(yeomanUi, "uiOptions.messages.artifact_with_name_generated", (a: string) => "")("testGenName"),
+          _.get(
+            yeomanUi,
+            "uiOptions.messages.artifact_with_name_generated",
+            (a: string) => ""
+          )("testGenName"),
           create_and_close,
           "",
-          null,
-        ),
+          null
+        )
       ).to.be.true;
     });
 
@@ -1260,55 +1649,86 @@ describe("yeomanui unit test", () => {
       const beforeGen = {
         targetFolderPath: "testDestinationRoot",
       };
-      changes.set(path.join("/", "testDestinationRoot", "webapp", "changes"), { isDirectory: true });
-      changes.set(path.join("/", "testDestinationRoot", "webapp", "changes", "file1"), { isDirectory: false });
+      changes.set(path.join("/", "testDestinationRoot", "webapp", "changes"), {
+        isDirectory: true,
+      });
+      changes.set(
+        path.join("/", "testDestinationRoot", "webapp", "changes", "file1"),
+        { isDirectory: false }
+      );
       const afterGen = {
         targetFolderPath: "testDestinationRoot",
         changeMap: changes,
       };
-      trackerWrapperMock.expects("updateGeneratorEnded").withArgs("testGenName").resolves();
+      trackerWrapperMock
+        .expects("updateGeneratorEnded")
+        .withArgs("testGenName")
+        .resolves();
       yeomanUi["onGeneratorSuccess"]("testGenName", beforeGen, afterGen);
       expect(
         doGeneratorDoneSpy.calledWith(
           true,
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          _.get(yeomanUi, "uiOptions.messages.artifact_with_name_generated", (a: string) => "")("testGenName"),
+          _.get(
+            yeomanUi,
+            "uiOptions.messages.artifact_with_name_generated",
+            (a: string) => ""
+          )("testGenName"),
           create_and_close,
           "files",
-          null,
-        ),
+          null
+        )
       ).to.be.true;
     });
 
     it("onGeneratorSuccess - targetFolderPath was changed by generator", () => {
       const beforeGen = { targetFolderPath: "testDestinationRoot" };
       const afterGen = {
-        targetFolderPath: path.join("/", "testDestinationRoot", "generatedProject"),
+        targetFolderPath: path.join(
+          "/",
+          "testDestinationRoot",
+          "generatedProject"
+        ),
         changeMap: changes,
       };
-      trackerWrapperMock.expects("updateGeneratorEnded").withArgs("testGenName").resolves();
+      trackerWrapperMock
+        .expects("updateGeneratorEnded")
+        .withArgs("testGenName")
+        .resolves();
       yeomanUi["onGeneratorSuccess"]("testGenName", beforeGen, afterGen);
       expect(
         doGeneratorDoneSpy.calledWith(
           true,
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          _.get(yeomanUi, "uiOptions.messages.artifact_with_name_generated", (a: string) => "")("testGenName"),
+          _.get(
+            yeomanUi,
+            "uiOptions.messages.artifact_with_name_generated",
+            (a: string) => ""
+          )("testGenName"),
           create_and_close,
           "files",
-          afterGen.targetFolderPath,
-        ),
+          afterGen.targetFolderPath
+        )
       ).to.be.true;
     });
 
     it("onGeneratorFailure", () => {
       yeomanUi["onGeneratorFailure"]("testGenName", "testError");
       expect(
-        doGeneratorDoneSpy.calledWith(false, `{"message":"testGenName generator failed - testError"}`, "", "files"),
+        doGeneratorDoneSpy.calledWith(
+          false,
+          `{"message":"testGenName generator failed - testError"}`,
+          "",
+          "files"
+        )
       ).to.be.true;
     });
 
     it("onGeneratorSuccess - generator type is project", () => {
-      wsConfigMock.expects("get").withExactArgs("ApplicationWizard.Workspace").returns(open_in_new_ws);
+      wsConfigMock
+        .expects("get")
+        .withExactArgs("ApplicationWizard.Workspace")
+        .returns(open_in_new_ws);
       yeomanUi["typesMap"].clear();
       yeomanUi["typesMap"].set("foodq:app", "project");
       const beforeGen = { targetFolderPath: "testDestinationRoot" };
@@ -1316,17 +1736,24 @@ describe("yeomanui unit test", () => {
         targetFolderPath: path.join("testDestinationRoot", "generatedProject"),
         changeMap: changes,
       };
-      trackerWrapperMock.expects("updateGeneratorEnded").withArgs("foodq:app").resolves();
+      trackerWrapperMock
+        .expects("updateGeneratorEnded")
+        .withArgs("foodq:app")
+        .resolves();
       yeomanUi["onGeneratorSuccess"]("foodq:app", beforeGen, afterGen);
       expect(
         doGeneratorDoneSpy.calledWith(
           true,
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          _.get(yeomanUi, "uiOptions.messages.artifact_with_name_generated", (a: string) => "")("foodq:app"),
+          _.get(
+            yeomanUi,
+            "uiOptions.messages.artifact_with_name_generated",
+            (a: string) => ""
+          )("foodq:app"),
           open_in_new_ws,
           "project",
-          afterGen.targetFolderPath,
-        ),
+          afterGen.targetFolderPath
+        )
       ).to.be.true;
     });
 
@@ -1339,17 +1766,28 @@ describe("yeomanui unit test", () => {
         targetFolderPath: "testDestinationRoot/generatedProject",
         changeMap: changes,
       };
-      trackerWrapperMock.expects("updateGeneratorEnded").withArgs("fiori-generator:app").resolves();
-      yeomanUi["onGeneratorSuccess"]("fiori-generator:app", beforeGen, afterGen);
+      trackerWrapperMock
+        .expects("updateGeneratorEnded")
+        .withArgs("fiori-generator:app")
+        .resolves();
+      yeomanUi["onGeneratorSuccess"](
+        "fiori-generator:app",
+        beforeGen,
+        afterGen
+      );
       expect(
         doGeneratorDoneSpy.calledWith(
           true,
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          _.get(yeomanUi, "uiOptions.messages.artifact_with_name_generated", (a: string) => "")("fiori-generator:app"),
+          _.get(
+            yeomanUi,
+            "uiOptions.messages.artifact_with_name_generated",
+            (a: string) => ""
+          )("fiori-generator:app"),
           create_and_close,
           "project",
-          afterGen.targetFolderPath,
-        ),
+          afterGen.targetFolderPath
+        )
       ).to.be.true;
     });
   });
@@ -1371,13 +1809,17 @@ describe("yeomanui unit test", () => {
         outputChannel,
         testLogger,
         GeneratorFilter.create(),
-        flowPromise.state,
+        flowPromise.state
       );
 
       yeomanUiInstance["addCustomQuestionEventHandlers"](questions);
       expect(questions[0]).to.not.have.property("testEvent");
 
-      yeomanUiInstance.registerCustomQuestionEventHandler("questionType", "testEvent", testEventFunction);
+      yeomanUiInstance.registerCustomQuestionEventHandler(
+        "questionType",
+        "testEvent",
+        testEventFunction
+      );
       yeomanUiInstance["addCustomQuestionEventHandlers"](questions);
       expect(questions[0]).to.have.property("testEvent");
       expect((questions[0] as any)["testEvent"]).to.equal(testEventFunction);
@@ -1396,11 +1838,21 @@ describe("yeomanui unit test", () => {
         testLogger,
         GeneratorFilter.create(),
 
-        flowPromise.state,
+        flowPromise.state
       );
-      yeomanUiInstance.registerCustomQuestionEventHandler("questionType", "testEvent", testEventFunction);
-      yeomanUiInstance["currentQuestions"] = [{ name: "question1", guiType: "questionType" }];
-      const response = await yeomanUiInstance["evaluateMethod"](null, "question1", "testEvent");
+      yeomanUiInstance.registerCustomQuestionEventHandler(
+        "questionType",
+        "testEvent",
+        testEventFunction
+      );
+      yeomanUiInstance["currentQuestions"] = [
+        { name: "question1", guiType: "questionType" },
+      ];
+      const response = await yeomanUiInstance["evaluateMethod"](
+        null,
+        "question1",
+        "testEvent"
+      );
       expect(response).to.be.true;
     });
 
@@ -1411,7 +1863,7 @@ describe("yeomanui unit test", () => {
         outputChannel,
         testLogger,
         GeneratorFilter.create(),
-        flowPromise.state,
+        flowPromise.state
       );
       yeomanUiInstance["currentQuestions"] = [
         {
@@ -1421,7 +1873,11 @@ describe("yeomanui unit test", () => {
           },
         },
       ];
-      const response = await yeomanUiInstance["evaluateMethod"](null, "question1", "method1");
+      const response = await yeomanUiInstance["evaluateMethod"](
+        null,
+        "question1",
+        "method1"
+      );
       expect(response).to.be.true;
     });
 
@@ -1432,9 +1888,13 @@ describe("yeomanui unit test", () => {
         outputChannel,
         testLogger,
         GeneratorFilter.create(),
-        flowPromise.state,
+        flowPromise.state
       );
-      const response = await yeomanUiInstance["evaluateMethod"](null, "question1", "method1");
+      const response = await yeomanUiInstance["evaluateMethod"](
+        null,
+        "question1",
+        "method1"
+      );
       expect(response).to.be.undefined;
     });
 
@@ -1445,7 +1905,7 @@ describe("yeomanui unit test", () => {
         outputChannel,
         testLogger,
         GeneratorFilter.create(),
-        flowPromise.state,
+        flowPromise.state
       );
       yeomanUiInstance["gen"] = Object.create({});
       yeomanUiInstance["gen"].options = {};
@@ -1471,7 +1931,7 @@ describe("yeomanui unit test", () => {
         outputChannel,
         testLogger,
         GeneratorFilter.create(),
-        flowPromise.state,
+        flowPromise.state
       );
       yeomanUiInstance["gen"] = Object.create({});
       yeomanUiInstance["gen"].options = {};


### PR DESCRIPTION
Sub generators tiles in Template Wizard.
If you want to show tile for sub generator you should add the following configuration in the package.json in the main generator:
`"additional_generators": [ { "namespace": "@sap/adaptation-project:adaptation-project", "displayName": "Sub Generator Tile", "description": "Sub generator description", "homePage": "https://home.page", "image": "image.png" } ]
`

1. namespace value should be the namespace of the sub generator.
2. displayName is used for the name in the tile.
3. description is used for the description in the tile.
4. homePage is used for the home page of the generator.
5. image is used for the icon in tile of the sub generator