### PR TITLE
Banner Support for yeoman-ui 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,8 @@ jobs:
           echo "EOF" >> $GITHUB_ENV
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        # workaround for https://github.com/softprops/action-gh-release/issues/628
+        uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631
         with:
           files: packages/*/*.vsix
           fail_on_unmatched_files: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.19.5](https://github.com/SAP/yeoman-ui/compare/v1.19.4...v1.19.5) (2025-06-10)
+
+**Note:** Version bump only for package root
+
 ## [1.19.4](https://github.com/SAP/yeoman-ui/compare/v1.19.3...v1.19.4) (2025-06-10)
 
 **Note:** Version bump only for package root

--- a/lerna.json
+++ b/lerna.json
@@ -10,5 +10,5 @@
       "allowBranch": "master"
     }
   },
-  "version": "1.19.4"
+  "version": "1.19.5"
 }

--- a/packages/backend/CHANGELOG.md
+++ b/packages/backend/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.19.5](https://github.com/SAP/yeoman-ui/compare/v1.19.4...v1.19.5) (2025-06-10)
+
+**Note:** Version bump only for package yeoman-ui
+
 ## [1.19.4](https://github.com/SAP/yeoman-ui/compare/v1.19.3...v1.19.4) (2025-06-10)
 
 **Note:** Version bump only for package yeoman-ui

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "yeoman-ui",
   "displayName": "Application Wizard",
-  "version": "1.19.4",
+  "version": "1.19.5",
   "private": true,
   "description": "Provides rich user experience for Yeoman generators.",
   "categories": [
@@ -185,7 +185,7 @@
   },
   "dependencies": {
     "@sap-devx/webview-rpc": "0.4.1",
-    "@sap-devx/yeoman-ui-types": "^1.19.4",
+    "@sap-devx/yeoman-ui-types": "^1.19.5",
     "@sap/bas-sdk": "3.7.11",
     "@sap/swa-for-sapbas-vsx": "2.0.4",
     "@vscode-logging/logger": "2.0.0",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -30,6 +30,7 @@
   "scripts": {
     "bundle": "webpack --mode production",
     "ci": "npm-run-all clean compile coverage bundle frontend:copy package coverage:copy",
+    "ci:skip-coverage": "npm-run-all clean compile bundle frontend:copy package",
     "clean": "shx rm -rf ./dist ./coverage *.vsix",
     "clean:frontend": "cd ./dist && shx rm -rf ./media",
     "compile": "tsc",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -30,7 +30,6 @@
   "scripts": {
     "bundle": "webpack --mode production",
     "ci": "npm-run-all clean compile coverage bundle frontend:copy package coverage:copy",
-    "ci:skip-coverage": "npm-run-all clean compile bundle frontend:copy package",
     "clean": "shx rm -rf ./dist ./coverage *.vsix",
     "clean:frontend": "cd ./dist && shx rm -rf ./media",
     "compile": "tsc",

--- a/packages/backend/src/vscode-youi-events.ts
+++ b/packages/backend/src/vscode-youi-events.ts
@@ -6,7 +6,7 @@ import { GeneratorOutput } from "./vscode-output";
 import { IChildLogger } from "@vscode-logging/logger";
 import { getClassLogger } from "./logger/logger-wrapper";
 import { getImage } from "./images/messageImages";
-import { AppWizard, MessageType, Severity } from "@sap-devx/yeoman-ui-types";
+import { AppWizard, MessageType, Severity, IBannerProps } from "@sap-devx/yeoman-ui-types";
 import { FolderUriConfig, getFolderUri, getValidFolderUri, WorkspaceFile, WsFoldersToAdd } from "./utils/workspaceFile";
 import { Constants } from "./utils/constants";
 
@@ -36,14 +36,7 @@ class YoUiAppWizard extends AppWizard {
     this.events.setAppWizardHeaderTitle(title, additionalInfo);
   }
 
-  public setBanner(bannerProps: {
-    text: string;
-    ariaLabel: string;
-    icon?: string;
-    iconColor?: string;
-    linkText?: string;
-    linkCommand?: string
-  }): void {
+  public setBanner(bannerProps: IBannerProps): void {
     this.events.setAppWizardBanner(bannerProps);
   }
 }
@@ -64,26 +57,13 @@ export class VSCodeYouiEvents implements YouiEvents {
     this.output = output;
     this.logger = getClassLogger("VSCodeYouiEvents");
     this.appWizard = new YoUiAppWizard(this);
-    this.webviewPanel.webview.onDidReceiveMessage((message) => {
-      if (message.command) {
-        // Execute the command received from the webview message
-        this.executeCommand(message.command, []);
-      }
-    });
   }
 
   public setAppWizardHeaderTitle(title: string, additionalInfo?: string): void {
     void this.rpc.invoke("setHeaderTitle", [title, additionalInfo]);
   }
 
-  public setAppWizardBanner(bannerProps: {
-    text: string;
-    ariaLabel: string;
-    icon?: string;
-    iconColor?: string;
-    linkText?: string;
-    linkCommand?: string;
-  }): void {
+  public setAppWizardBanner(bannerProps: IBannerProps): void {
     // This method allows generators to update the App Wizard banner
     void this.rpc.invoke("setBanner", [bannerProps]);
   }

--- a/packages/backend/src/vscode-youi-events.ts
+++ b/packages/backend/src/vscode-youi-events.ts
@@ -35,6 +35,17 @@ class YoUiAppWizard extends AppWizard {
   public setHeaderTitle(title: string, additionalInfo?: string): void {
     this.events.setAppWizardHeaderTitle(title, additionalInfo);
   }
+
+  public setBanner(bannerProps: {
+    text: string;
+    ariaLabel: string;
+    icon?: string;
+    iconColor?: string;
+    linkText?: string;
+    linkCommand?: string
+  }): void {
+    this.events.setAppWizardBanner(bannerProps);
+  }
 }
 
 export class VSCodeYouiEvents implements YouiEvents {
@@ -53,10 +64,28 @@ export class VSCodeYouiEvents implements YouiEvents {
     this.output = output;
     this.logger = getClassLogger("VSCodeYouiEvents");
     this.appWizard = new YoUiAppWizard(this);
+    this.webviewPanel.webview.onDidReceiveMessage((message) => {
+      if (message.command) {
+        // Execute the command received from the webview message
+        this.executeCommand(message.command, []);
+      }
+    });
   }
 
   public setAppWizardHeaderTitle(title: string, additionalInfo?: string): void {
     void this.rpc.invoke("setHeaderTitle", [title, additionalInfo]);
+  }
+
+  public setAppWizardBanner(bannerProps: {
+    text: string;
+    ariaLabel: string;
+    icon?: string;
+    iconColor?: string;
+    linkText?: string;
+    linkCommand?: string;
+  }): void {
+    // This method allows generators to update the App Wizard banner
+    void this.rpc.invoke("setBanner", [bannerProps]);
   }
 
   public doGeneratorDone(

--- a/packages/backend/test/vscode-youi-events.spec.ts
+++ b/packages/backend/test/vscode-youi-events.spec.ts
@@ -84,7 +84,13 @@ describe("vscode-youi-events unit test", () => {
   });
 
   beforeEach(() => {
-    const webViewPanel: any = { dispose: () => true };
+    const webViewPanel: any = { 
+      dispose: () => true,
+      webview: {
+        onDidReceiveMessage: sandbox.stub(), 
+        postMessage: sandbox.stub()
+      }
+    };
     loggerWrapperMock = sandbox.mock(loggerWrapper);
     loggerWrapperMock.expects("getClassLogger").returns(testLogger);
     events = new VSCodeYouiEvents(rpc, webViewPanel, messages.default, generatorOutput);

--- a/packages/backend/test/vscode-youi-events.spec.ts
+++ b/packages/backend/test/vscode-youi-events.spec.ts
@@ -234,7 +234,7 @@ describe("vscode-youi-events unit test", () => {
     const bannerProps: IBannerProps = {
       text: "Test Banner",
       ariaLabel: "Test Banner Label",
-      showBanner: true,
+      displayBannerForStep: "testStep",
       icon: { source: "mdi-check-circle", type: "mdi" },
       action: { text: "Click Me", url: "https://example.com" },
       triggerActionFrom: "banner",

--- a/packages/backend/test/vscode-youi-events.spec.ts
+++ b/packages/backend/test/vscode-youi-events.spec.ts
@@ -4,7 +4,7 @@ import { createSandbox, SinonSandbox, SinonMock } from "sinon";
 import * as _ from "lodash";
 import { IMethod, IPromiseCallbacks, IRpc } from "@sap-devx/webview-rpc/out.ext/rpc-common";
 import * as messages from "../src/messages";
-import { MessageType, Severity } from "@sap-devx/yeoman-ui-types";
+import { MessageType, Severity, IBannerProps } from "@sap-devx/yeoman-ui-types";
 import { GeneratorOutput } from "../src/vscode-output";
 import { Constants } from "../src/utils/constants";
 import * as loggerWrapper from "../src/logger/logger-wrapper";
@@ -84,13 +84,7 @@ describe("vscode-youi-events unit test", () => {
   });
 
   beforeEach(() => {
-    const webViewPanel: any = { 
-      dispose: () => true,
-      webview: {
-        onDidReceiveMessage: sandbox.stub(), 
-        postMessage: sandbox.stub()
-      }
-    };
+    const webViewPanel: any = { dispose: () => true };
     loggerWrapperMock = sandbox.mock(loggerWrapper);
     loggerWrapperMock.expects("getClassLogger").returns(testLogger);
     events = new VSCodeYouiEvents(rpc, webViewPanel, messages.default, generatorOutput);
@@ -234,6 +228,19 @@ describe("vscode-youi-events unit test", () => {
     const testInfo = "testInfo";
     rpcMock.expects("invoke").withExactArgs("setHeaderTitle", [testTitle, testInfo]);
     events.setAppWizardHeaderTitle(testTitle, testInfo);
+  });
+
+  it("setBanner", () => {
+    const bannerProps: IBannerProps = {
+      text: "Test Banner",
+      ariaLabel: "Test Banner Label",
+      showBanner: true,
+      icon: { source: "mdi-check-circle", type: "mdi" },
+      action: { text: "Click Me", url: "https://example.com" },
+      triggerActionFrom: "banner"
+    }
+    rpcMock.expects("invoke").withExactArgs("setBanner", [bannerProps]);
+    events.setAppWizardBanner(bannerProps);
   });
 
   describe("showProgress", () => {

--- a/packages/backend/test/vscode-youi-events.spec.ts
+++ b/packages/backend/test/vscode-youi-events.spec.ts
@@ -237,8 +237,8 @@ describe("vscode-youi-events unit test", () => {
       showBanner: true,
       icon: { source: "mdi-check-circle", type: "mdi" },
       action: { text: "Click Me", url: "https://example.com" },
-      triggerActionFrom: "banner"
-    }
+      triggerActionFrom: "banner",
+    };
     rpcMock.expects("invoke").withExactArgs("setBanner", [bannerProps]);
     events.setAppWizardBanner(bannerProps);
   });

--- a/packages/backend/test/yeomanui.spec.ts
+++ b/packages/backend/test/yeomanui.spec.ts
@@ -12,7 +12,7 @@ import { GeneratorFilter } from "../src/filter";
 import { homedir } from "os";
 import messages from "../src/messages";
 import { AnalyticsWrapper } from "../src/usage-report/usage-analytics-wrapper";
-import { AppWizard, MessageType } from "@sap-devx/yeoman-ui-types";
+import { AppWizard, MessageType, IBannerProps } from "@sap-devx/yeoman-ui-types";
 import { Env } from "../src/utils/env";
 import Environment = require("yeoman-environment");
 import { createFlowPromise } from "../src/utils/promise";
@@ -51,14 +51,7 @@ describe("yeomanui unit test", () => {
       return;
     }
 
-    public setBanner(bannerProps: {
-      text: string;
-      ariaLabel: string;
-      icon?: string;
-      iconColor?: string;
-      linkText?: string;
-      linkCommand?: string;
-    }): void {
+    public setBanner(bannerProps: IBannerProps): void {
       return;
     }
   }

--- a/packages/backend/test/yeomanui.spec.ts
+++ b/packages/backend/test/yeomanui.spec.ts
@@ -12,7 +12,7 @@ import { GeneratorFilter } from "../src/filter";
 import { homedir } from "os";
 import messages from "../src/messages";
 import { AnalyticsWrapper } from "../src/usage-report/usage-analytics-wrapper";
-import { AppWizard, MessageType, IBannerProps } from "@sap-devx/yeoman-ui-types";
+import { AppWizard, MessageType } from "@sap-devx/yeoman-ui-types";
 import { Env } from "../src/utils/env";
 import Environment = require("yeoman-environment");
 import { createFlowPromise } from "../src/utils/promise";
@@ -51,7 +51,7 @@ describe("yeomanui unit test", () => {
       return;
     }
 
-    public setBanner(bannerProps: IBannerProps): void {
+    public setBanner(): void {
       return;
     }
   }

--- a/packages/backend/test/yeomanui.spec.ts
+++ b/packages/backend/test/yeomanui.spec.ts
@@ -50,6 +50,17 @@ describe("yeomanui unit test", () => {
     public setHeaderTitle(): void {
       return;
     }
+
+    public setBanner(bannerProps: {
+      text: string;
+      ariaLabel: string;
+      icon?: string;
+      iconColor?: string;
+      linkText?: string;
+      linkCommand?: string;
+    }): void {
+      return;
+    }
   }
   const appWizard: AppWizard = new TestAppWizard();
   class TestEvents implements YouiEvents {

--- a/packages/frontend/CHANGELOG.md
+++ b/packages/frontend/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.19.5](https://github.com/SAP/yeoman-ui/compare/v1.19.4...v1.19.5) (2025-06-10)
+
+**Note:** Version bump only for package yeoman-ui-frontend
+
 ## [1.19.4](https://github.com/SAP/yeoman-ui/compare/v1.19.3...v1.19.4) (2025-06-10)
 
 **Note:** Version bump only for package yeoman-ui-frontend

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "yeoman-ui-frontend",
   "displayName": "Application Wizard Frontend",
-  "version": "1.19.4",
+  "version": "1.19.5",
   "private": true,
   "description": "Frontend for the application wizard framework",
   "license": "Apache 2.0",
@@ -69,7 +69,7 @@
     "@sap-devx/inquirer-gui-radio-plugin": "3.4.2",
     "@sap-devx/inquirer-gui-tiles-plugin": "3.0.3",
     "@sap-devx/webview-rpc": "0.4.1",
-    "@sap-devx/yeoman-ui-types": "^1.19.4",
+    "@sap-devx/yeoman-ui-types": "^1.19.5",
     "core-js": "^3.8.3",
     "material-design-icons-iconfont": "6.1.0",
     "vue": "^3.3.4",

--- a/packages/frontend/src/components/YOUIBanner.vue
+++ b/packages/frontend/src/components/YOUIBanner.vue
@@ -1,60 +1,51 @@
 <template>
   <!-- Banner container -->
-  <v-banner 
-    class="banner-container mb-6 mt-2" 
-    role="banner" 
-    elevation="0" 
-    :aria-label="bannerProps.ariaLabel" 
+  <v-banner
+    class="banner-container mb-6 mt-2"
+    role="banner"
+    elevation="0"
+    :aria-label="bannerProps.ariaLabel"
     flat
-    @click="bannerProps.triggerActionFrom === 'banner' ? triggerCommand(bannerProps.action?.command) : null">
-    
+    @click="bannerProps.triggerActionFrom === 'banner' ? triggerCommand(bannerProps.action?.command) : null"
+  >
     <!-- Banner content -->
     <div class="banner-content">
-      
       <!-- Banner icon -->
       <div class="banner-icon">
         <!-- Render image if icon type is "image" -->
-        <img 
-          v-if="bannerProps.icon?.type === 'image'" 
-          :src="bannerProps.icon?.source" 
-          :alt="bannerProps.ariaLabel" 
-        />
+        <img v-if="bannerProps.icon?.type === 'image'" :src="bannerProps.icon?.source" :alt="bannerProps.ariaLabel" />
         <!-- Render v-icon if icon type is "mdi" -->
         <v-icon v-else-if="bannerProps.icon?.type === 'mdi'">
           {{ bannerProps.icon?.source }}
         </v-icon>
       </div>
-      
-      <!-- Banner text -->
+
+      <!-- Banner text and actions -->
       <div class="banner-text">
         <span>{{ bannerProps.text }}</span>
-        
-        <!-- Render action text if triggerActionFrom is "banner" -->
-        <span
-          v-if="bannerProps.triggerActionFrom === 'banner' && bannerProps.action?.text"
-          class="banner-link-text">
+
+        <!-- Render action for "banner" trigger -->
+        <span v-if="bannerProps.triggerActionFrom === 'banner' && bannerProps.action?.text" class="banner-link-text">
           {{ bannerProps.action?.text }}
         </span>
-        
-        <!-- Render clickable action text if triggerActionFrom is "link" -->
+
+        <!-- Render clickable command link for "link" trigger -->
         <span
-          v-if="bannerProps.triggerActionFrom === 'link' && bannerProps.action?.text"
-          class="banner-link-text banner-link">
-          <a 
-            href="javascript:void(0)" 
-            @click="triggerCommand(bannerProps.action?.command)">
+          v-if="bannerProps.triggerActionFrom === 'link' && bannerProps.action?.text && bannerProps.action?.command"
+          class="banner-link-text banner-link"
+        >
+          <a href="javascript:void(0)" @click="triggerCommand(bannerProps.action?.command)">
             {{ bannerProps.action?.text }}
           </a>
         </span>
-        
-        <!-- Render clickable URL if triggerActionFrom is "link" -->
+
+        <!-- Render clickable URL link for "link" trigger -->
         <span
           v-if="bannerProps.triggerActionFrom === 'link' && bannerProps.action?.url"
-          class="banner-link-text banner-link">
-          <a 
-            :href="bannerProps.action?.url" 
-            target="_blank">
-            {{ bannerProps.linkText }}
+          class="banner-link-text banner-link"
+        >
+          <a :href="bannerProps.action?.url" target="_blank">
+            {{ bannerProps.action?.text }}
           </a>
         </span>
       </div>
@@ -70,15 +61,14 @@ const props = defineProps({
     type: Object,
     required: true,
     default: () => ({
-      stepName: "",
       text: "",
       ariaLabel: "Banner",
       icon: {},
       action: {},
-      triggerActionFrom: "banner", 
+      triggerActionFrom: "banner",
       linkText: "",
-    })
-  }
+    }),
+  },
 });
 
 const emit = defineEmits(["parent-execute-command"]);
@@ -94,28 +84,26 @@ const triggerCommand = (event) => {
 </script>
 
 <style lang="scss">
-
-$icon-background-color: #005FB8;
+$icon-background-color: #005fb8;
 $background-color: var(--vscode-sideBar-background, #2a2d2e);
 $focus-border-color: var(--vscode-focusBorder, $icon-background-color);
 $text-link-color: var(--vscode-textLink-foreground, $icon-background-color);
 $text-link-hover-color: var(--vscode-textLink-activeForeground, #004999);
 
-
 .v-banner.banner-container {
-  background-color: $background-color; 
+  background-color: $background-color;
   border-radius: 3px;
   box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.1) !important;
   display: flex;
   align-items: center;
   justify-content: flex-start;
-  border: 1px solid transparent; 
+  border: 1px solid transparent;
   cursor: pointer;
   height: 48px;
 }
 
 .v-banner.banner-container:hover {
-  border: 1px solid $focus-border-color; 
+  border: 1px solid $focus-border-color;
 }
 
 .banner-content {
@@ -135,19 +123,19 @@ $text-link-hover-color: var(--vscode-textLink-activeForeground, #004999);
 
 .banner-text {
   white-space: pre-wrap;
-  color: var(--vscode-editor-foreground, #cccccc); 
+  color: var(--vscode-editor-foreground, #cccccc);
   font-size: 13px;
 }
 
 .banner-link-text {
-  color: $text-link-color; 
-  text-decoration: underline; 
-  font-weight: bold; 
-  width: fit-content; 
+  color: $text-link-color;
+  text-decoration: underline;
+  font-weight: bold;
+  width: fit-content;
 }
 
 .banner-link {
-  cursor: pointer; 
+  cursor: pointer;
   &:hover {
     text-decoration: none;
     color: $text-link-hover-color;

--- a/packages/frontend/src/components/YOUIBanner.vue
+++ b/packages/frontend/src/components/YOUIBanner.vue
@@ -1,7 +1,11 @@
 <template>
   <!-- Banner container -->
   <v-banner
-    class="banner-container mb-6 mt-2"
+    :class="
+      bannerProps.triggerActionFrom === 'banner'
+        ? 'banner-container banner-hover mb-6 mt-2'
+        : 'banner-container mb-6 mt-2'
+    "
     role="banner"
     elevation="0"
     :aria-label="bannerProps.ariaLabel"
@@ -32,7 +36,7 @@
         <!-- Render clickable command link for "link" trigger -->
         <span
           v-if="bannerProps.triggerActionFrom === 'link' && bannerProps.action?.text && bannerProps.action?.command"
-          class="banner-link-text banner-link"
+          class="banner-link-text banner-link-hover"
         >
           <a href="javascript:void(0)" @click="triggerCommand(bannerProps.action?.command)">
             {{ bannerProps.action?.text }}
@@ -42,7 +46,7 @@
         <!-- Render clickable URL link for "link" trigger -->
         <span
           v-if="bannerProps.triggerActionFrom === 'link' && bannerProps.action?.url"
-          class="banner-link-text banner-link"
+          class="banner-link-text banner-link-hover"
         >
           <a :href="bannerProps.action?.url" target="_blank">
             {{ bannerProps.action?.text }}
@@ -83,61 +87,80 @@ const triggerCommand = (event) => {
 </script>
 
 <style lang="scss">
+// Define color variables
 $icon-background-color: #005fb8;
-$background-color: var(--vscode-sideBar-background, #2a2d2e);
+$background-color: var(--vscode-editorWidget-background, #f8f8f8);
 $focus-border-color: var(--vscode-focusBorder, $icon-background-color);
 $text-link-color: var(--vscode-textLink-foreground, $icon-background-color);
-$text-link-hover-color: var(--vscode-textLink-activeForeground, #004999);
 
+// Banner container styles
 .v-banner.banner-container {
   background-color: $background-color;
   border-radius: 3px;
-  box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.1) !important;
+  box-shadow: 0px 4px 8px 0px var(--vscode-widget-shadow, rgba(0, 0, 0, 0.1)) !important;
   display: flex;
   align-items: center;
   justify-content: flex-start;
-  border: 1px solid transparent;
-  cursor: pointer;
+  border: 1px solid var(--vscode-editorWidget-border, #c8c8c8);
   height: 48px;
+  transition:
+    border-color 0.2s ease,
+    box-shadow 0.2s ease;
+
+  &.banner-hover {
+    cursor: pointer;
+  }
+
+  &:hover {
+    border: 1px solid $focus-border-color;
+    box-shadow: 0px 6px 12px 0px var(--vscode-widget-shadow, rgba(0, 0, 0, 0.2)) !important;
+
+    .banner-link-text {
+      text-decoration: none;
+    }
+  }
 }
 
-.v-banner.banner-container:hover {
-  border: 1px solid $focus-border-color;
-}
-
+// Banner content styles
 .banner-content {
   display: flex;
   align-items: center;
   gap: 14px;
 }
 
+// Banner icon styles
 .banner-icon {
   display: flex;
   align-items: center;
-  font-size: inherit;
+  justify-content: center;
   background-color: $icon-background-color;
-  border-radius: 2px;
   padding: 4px;
+  width: 24px;
+  height: 24px;
+  border-radius: 2px;
 }
 
+// Banner text styles
 .banner-text {
   white-space: pre-wrap;
-  color: var(--vscode-editor-foreground, #cccccc);
+  color: var(--vscode-foreground, #3b3b3b);
   font-size: 13px;
+  line-height: 1.5;
 }
 
+// Banner link text styles
 .banner-link-text {
   color: $text-link-color;
   text-decoration: underline;
   font-weight: bold;
   width: fit-content;
-}
-
-.banner-link {
   cursor: pointer;
+  transition:
+    color 0.2s ease,
+    text-decoration 0.2s ease;
+
   &:hover {
     text-decoration: none;
-    color: $text-link-hover-color;
   }
 }
 </style>

--- a/packages/frontend/src/components/YOUIBanner.vue
+++ b/packages/frontend/src/components/YOUIBanner.vue
@@ -97,12 +97,15 @@ $text-link-color: var(--vscode-textLink-foreground, $icon-background-color);
 .v-banner.banner-container {
   background-color: $background-color;
   border-radius: 3px;
+  padding: 12px;
   box-shadow: 0px 4px 8px 0px var(--vscode-widget-shadow, rgba(0, 0, 0, 0.1)) !important;
   display: flex;
   align-items: center;
+  flex-direction: row;
   justify-content: flex-start;
+  flex-wrap: wrap;
+  height: auto;
   border: 1px solid var(--vscode-editorWidget-border, #c8c8c8);
-  height: 48px;
   transition:
     border-color 0.2s ease,
     box-shadow 0.2s ease;
@@ -138,11 +141,19 @@ $text-link-color: var(--vscode-textLink-foreground, $icon-background-color);
   width: 24px;
   height: 24px;
   border-radius: 2px;
+  flex: none;
+
+  img,
+  v-icon {
+    object-fit: scale-down;
+    width: 100%;
+    height: 100%;
+  }
 }
 
 // Banner text styles
 .banner-text {
-  white-space: pre-wrap;
+  white-space: normal;
   color: var(--vscode-foreground, #3b3b3b);
   font-size: 13px;
   line-height: 1.5;

--- a/packages/frontend/src/components/YOUIBanner.vue
+++ b/packages/frontend/src/components/YOUIBanner.vue
@@ -65,9 +65,9 @@ const props = defineProps({
       ariaLabel: "Banner",
       icon: {},
       action: {},
-      triggerActionFrom: "banner"
-    })
-  }
+      triggerActionFrom: "banner",
+    }),
+  },
 });
 
 const emit = defineEmits(["parent-execute-command"]);

--- a/packages/frontend/src/components/YOUIBanner.vue
+++ b/packages/frontend/src/components/YOUIBanner.vue
@@ -1,0 +1,104 @@
+<template>
+  <v-banner 
+    class="banner-container mb-2" 
+    role="banner" 
+    elevation="0" 
+    :aria-label="bannerProps.ariaLabel" 
+    flat>
+    <div class="banner-content">
+      <div class="banner-icon">
+        <v-icon v-if="bannerProps.icon" :color="bannerProps.iconColor">{{ bannerProps.icon }}</v-icon>
+      </div>
+      <div class="banner-text">
+        <span>{{ bannerProps.text }}</span>
+        <span
+          v-if="bannerProps.linkText && bannerProps.linkCommand"
+          class="banner-link"
+          @click="triggerCommand"
+        >
+          <a href="javascript:void(0)">{{ bannerProps.linkText }}</a>
+        </span>
+      </div>
+    </div>
+  </v-banner>
+</template>
+
+<script setup>
+import { toRefs } from "vue";
+
+const props = defineProps({
+  bannerProps: {
+    type: Object,
+    required: true,
+    default: () => ({
+      icon: null,
+      iconColor: "blue",
+      text: "",
+      linkText: "",
+      linkCommand: "",
+      role: "banner",
+      ariaLabel: "Notification Banner"
+    })
+  },
+  vscode: { 
+    type: Object,
+    required: true,
+  },
+});
+
+const { bannerProps, vscode } = toRefs(props);
+
+const triggerCommand = () => {
+  if (bannerProps.value.linkCommand && vscode) {
+    // Send the command to the backend
+    vscode.value.postMessage({
+      command: bannerProps.value.linkCommand
+    });
+  } else {
+    console.warn("No linkCommand provided for YOUIBanner.");
+  }
+};
+</script>
+
+<style lang="scss">
+
+.v-banner.banner-container {
+  color: var(--vscode-foreground, #cccccc); 
+  background-color: var(--vscode-sideBar-background, #2a2d2e); 
+  box-shadow: 4px 4px 10px rgba(0, 0, 0, 0.2);
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+}
+
+.banner-content {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.banner-icon {
+  display: flex;
+  align-items: center;
+  font-size: inherit;
+}
+
+.banner-text {
+  white-space: pre-wrap;
+  color: var(--vscode-foreground, #cccccc); 
+  font-size: inherit;
+}
+
+.banner-link {
+  color: var(--vscode-textLink-foreground, #3794ff); 
+  text-decoration: underline; 
+  cursor: pointer; 
+  font-weight: bold; 
+  width: fit-content; 
+
+  &:hover {
+    text-decoration: none;
+    color: var(--vscode-textLink-activeForeground, #004999);
+  }
+}
+</style>

--- a/packages/frontend/src/components/YOUIBanner.vue
+++ b/packages/frontend/src/components/YOUIBanner.vue
@@ -1,22 +1,61 @@
 <template>
+  <!-- Banner container -->
   <v-banner 
-    class="banner-container mb-2" 
+    class="banner-container mb-6 mt-2" 
     role="banner" 
     elevation="0" 
     :aria-label="bannerProps.ariaLabel" 
-    flat>
+    flat
+    @click="bannerProps.triggerActionFrom === 'banner' ? triggerCommand(bannerProps.action?.command) : null">
+    
+    <!-- Banner content -->
     <div class="banner-content">
+      
+      <!-- Banner icon -->
       <div class="banner-icon">
-        <v-icon v-if="bannerProps.icon" :color="bannerProps.iconColor">{{ bannerProps.icon }}</v-icon>
+        <!-- Render image if icon type is "image" -->
+        <img 
+          v-if="bannerProps.icon?.type === 'image'" 
+          :src="bannerProps.icon?.source" 
+          :alt="bannerProps.ariaLabel" 
+        />
+        <!-- Render v-icon if icon type is "mdi" -->
+        <v-icon v-else-if="bannerProps.icon?.type === 'mdi'">
+          {{ bannerProps.icon?.source }}
+        </v-icon>
       </div>
+      
+      <!-- Banner text -->
       <div class="banner-text">
         <span>{{ bannerProps.text }}</span>
+        
+        <!-- Render action text if triggerActionFrom is "banner" -->
         <span
-          v-if="bannerProps.linkText && bannerProps.linkCommand"
-          class="banner-link"
-          @click="triggerCommand"
-        >
-          <a href="javascript:void(0)">{{ bannerProps.linkText }}</a>
+          v-if="bannerProps.triggerActionFrom === 'banner' && bannerProps.action?.text"
+          class="banner-link-text">
+          {{ bannerProps.action?.text }}
+        </span>
+        
+        <!-- Render clickable action text if triggerActionFrom is "link" -->
+        <span
+          v-if="bannerProps.triggerActionFrom === 'link' && bannerProps.action?.text"
+          class="banner-link-text banner-link">
+          <a 
+            href="javascript:void(0)" 
+            @click="triggerCommand(bannerProps.action?.command)">
+            {{ bannerProps.action?.text }}
+          </a>
+        </span>
+        
+        <!-- Render clickable URL if triggerActionFrom is "link" -->
+        <span
+          v-if="bannerProps.triggerActionFrom === 'link' && bannerProps.action?.url"
+          class="banner-link-text banner-link">
+          <a 
+            :href="bannerProps.action?.url" 
+            target="_blank">
+            {{ bannerProps.linkText }}
+          </a>
         </span>
       </div>
     </div>
@@ -24,81 +63,94 @@
 </template>
 
 <script setup>
-import { toRefs } from "vue";
+import { toRefs, defineEmits } from "vue";
 
 const props = defineProps({
   bannerProps: {
     type: Object,
     required: true,
     default: () => ({
-      icon: null,
-      iconColor: "blue",
+      stepName: "",
       text: "",
+      ariaLabel: "Banner",
+      icon: {},
+      action: {},
+      triggerActionFrom: "banner", 
       linkText: "",
-      linkCommand: "",
-      role: "banner",
-      ariaLabel: "Notification Banner"
     })
-  },
-  vscode: { 
-    type: Object,
-    required: true,
-  },
+  }
 });
 
-const { bannerProps, vscode } = toRefs(props);
+const emit = defineEmits(["parent-execute-command"]);
+const { bannerProps } = toRefs(props);
 
-const triggerCommand = () => {
-  if (bannerProps.value.linkCommand && vscode) {
-    // Send the command to the backend
-    vscode.value.postMessage({
-      command: bannerProps.value.linkCommand
-    });
-  } else {
-    console.warn("No linkCommand provided for YOUIBanner.");
-  }
+/**
+ * Trigger the command action and emit the event to the parent component
+ * @param {Object} event - The event object
+ */
+const triggerCommand = (event) => {
+  emit("parent-execute-command", event);
 };
 </script>
 
 <style lang="scss">
 
+$icon-background-color: #005FB8;
+$background-color: var(--vscode-sideBar-background, #2a2d2e);
+$focus-border-color: var(--vscode-focusBorder, $icon-background-color);
+$text-link-color: var(--vscode-textLink-foreground, $icon-background-color);
+$text-link-hover-color: var(--vscode-textLink-activeForeground, #004999);
+
+
 .v-banner.banner-container {
-  color: var(--vscode-foreground, #cccccc); 
-  background-color: var(--vscode-sideBar-background, #2a2d2e); 
-  box-shadow: 4px 4px 10px rgba(0, 0, 0, 0.2);
+  background-color: $background-color; 
+  border-radius: 3px;
+  box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.1) !important;
   display: flex;
   align-items: center;
   justify-content: flex-start;
+  border: 1px solid transparent; 
+  cursor: pointer;
+  height: 48px;
+}
+
+.v-banner.banner-container:hover {
+  border: 1px solid $focus-border-color; 
 }
 
 .banner-content {
   display: flex;
   align-items: center;
-  gap: 16px;
+  gap: 14px;
 }
 
 .banner-icon {
   display: flex;
   align-items: center;
   font-size: inherit;
+  background-color: $icon-background-color;
+  border-radius: 2px;
+  padding: 4px;
 }
 
 .banner-text {
   white-space: pre-wrap;
-  color: var(--vscode-foreground, #cccccc); 
-  font-size: inherit;
+  color: var(--vscode-editor-foreground, #cccccc); 
+  font-size: 13px;
+}
+
+.banner-link-text {
+  color: $text-link-color; 
+  text-decoration: underline; 
+  font-weight: bold; 
+  width: fit-content; 
 }
 
 .banner-link {
-  color: var(--vscode-textLink-foreground, #3794ff); 
-  text-decoration: underline; 
   cursor: pointer; 
-  font-weight: bold; 
-  width: fit-content; 
-
   &:hover {
     text-decoration: none;
-    color: var(--vscode-textLink-activeForeground, #004999);
+    color: $text-link-hover-color;
   }
 }
 </style>

--- a/packages/frontend/src/components/YOUIBanner.vue
+++ b/packages/frontend/src/components/YOUIBanner.vue
@@ -65,10 +65,9 @@ const props = defineProps({
       ariaLabel: "Banner",
       icon: {},
       action: {},
-      triggerActionFrom: "banner",
-      linkText: "",
-    }),
-  },
+      triggerActionFrom: "banner"
+    })
+  }
 });
 
 const emit = defineEmits(["parent-execute-command"]);

--- a/packages/frontend/src/youi/App.vue
+++ b/packages/frontend/src/youi/App.vue
@@ -176,7 +176,7 @@ function initialState() {
       icon: {},
       action: {},
       triggerActionFrom: "banner",
-      showBanner: false
+      showBanner: false,
     },
   };
 }
@@ -365,7 +365,7 @@ export default {
         icon: icon ? { source: icon.source, type: icon.type } : undefined,
         action: action ? { ...action } : undefined,
         triggerActionFrom: triggerActionFrom || "banner",
-        showBanner
+        showBanner,
       };
     },
     setHeaderTitle(title, info) {

--- a/packages/frontend/src/youi/App.vue
+++ b/packages/frontend/src/youi/App.vue
@@ -37,9 +37,9 @@
           <v-col>
             <YOUIDone v-if="isDone" :done-status="doneStatus" :done-message="doneMessage" :done-path="donePath" />
             <YOUIBanner
-              v-if="bannerProps.text && bannerProps.ariaLabel"
+              v-if="bannerProps.showBanner && bannerProps.text && bannerProps.ariaLabel"
               :bannerProps="bannerProps"
-              :vscode="getVsCodeApi()"
+              @parent-execute-command="executeCommand"
             />
             <YOUIPromptInfo v-if="currentPrompt && !isDone" :current-prompt="currentPrompt" />
             <v-slide-x-transition>
@@ -171,12 +171,12 @@ function initialState() {
     headerInfo: "",
     currentAnswerTexts: {}, // Answer state for navigation answer history
     bannerProps: {
-      icon: "",
-      iconColor: "",
       text: "",
+      ariaLabel: "Banner",
+      icon: {},
+      action: {},
+      triggerActionFrom: "banner", 
       linkText: "",
-      linkCommand: "",
-      ariaLabel: "Notification Banner"
     }
   };
 }
@@ -331,7 +331,8 @@ export default {
         command.id = cmdOrEvent.target.getAttribute("command");
         command.params = cmdOrEvent.target.getAttribute("params");
       }
-      this.rpc.invoke("executeCommand", [command.id, JSON.parse(JSON.stringify(command.params))]);
+      const params = command.params ? JSON.parse(JSON.stringify(command.params)) : null;
+      this.rpc.invoke("executeCommand", [command.id, params]);
     },
     back() {
       return this.gotoStep(1); // go 1 step back
@@ -357,14 +358,15 @@ export default {
         this.reject(error);
       }
     },
-    setBanner({ icon, iconColor, text, linkText, linkCommand, ariaLabel }) {
+    setBanner({ icon, text, action, ariaLabel, triggerActionFrom, linkText, showBanner = false }) {
       this.bannerProps = {
-        icon,
-        iconColor,
         text,
-        linkText,
-        linkCommand,
-        ariaLabel
+        ariaLabel,
+        icon: icon ? { source: icon.source, type: icon.type } : undefined,
+        action: action ? { ...action } : undefined, 
+        triggerActionFrom: triggerActionFrom || "banner", 
+        linkText: linkText,
+        showBanner
       };
     },
     setHeaderTitle(title, info) {

--- a/packages/frontend/src/youi/App.vue
+++ b/packages/frontend/src/youi/App.vue
@@ -37,7 +37,7 @@
           <v-col>
             <YOUIDone v-if="isDone" :done-status="doneStatus" :done-message="doneMessage" :done-path="donePath" />
             <YOUIBanner
-              v-if="bannerProps.text && bannerProps.ariaLabel"
+              v-if="shouldDisplayBanner"
               :banner-props="bannerProps"
               @parent-execute-command="executeCommand"
             />
@@ -176,6 +176,7 @@ function initialState() {
       icon: {},
       action: {},
       triggerActionFrom: "banner",
+      displayBannerForStep: "",
     },
   };
 }
@@ -236,6 +237,16 @@ export default {
     },
     currentPrompt() {
       return _get(this.prompts, "[" + this.promptIndex + "]");
+    },
+    shouldDisplayBanner() {
+      if (this.bannerProps.displayBannerForStep) {
+        return (
+          this.bannerProps.displayBannerForStep === this.currentPrompt?.name &&
+          this.bannerProps.text &&
+          this.bannerProps.ariaLabel
+        );
+      }
+      return this.bannerProps.text && this.bannerProps.ariaLabel;
     },
     isNoGenerators() {
       const promptName = _get(this.currentPrompt, "name");
@@ -357,13 +368,14 @@ export default {
         this.reject(error);
       }
     },
-    setBanner({ icon, text, action, ariaLabel, triggerActionFrom }) {
+    setBanner({ icon, text, action, ariaLabel, triggerActionFrom, displayBannerForStep }) {
       this.bannerProps = {
+        displayBannerForStep,
         text,
         ariaLabel,
         icon: icon ? { source: icon.source, type: icon.type } : undefined,
         action: action ? { ...action } : undefined,
-        triggerActionFrom: triggerActionFrom || "banner",
+        triggerActionFrom: triggerActionFrom ?? "banner",
       };
     },
     setHeaderTitle(title, info) {

--- a/packages/frontend/src/youi/App.vue
+++ b/packages/frontend/src/youi/App.vue
@@ -37,7 +37,7 @@
           <v-col>
             <YOUIDone v-if="isDone" :done-status="doneStatus" :done-message="doneMessage" :done-path="donePath" />
             <YOUIBanner
-              v-if="bannerProps.showBanner && bannerProps.text && bannerProps.ariaLabel"
+              v-if="bannerProps.text && bannerProps.ariaLabel"
               :banner-props="bannerProps"
               @parent-execute-command="executeCommand"
             />
@@ -176,7 +176,6 @@ function initialState() {
       icon: {},
       action: {},
       triggerActionFrom: "banner",
-      showBanner: false,
     },
   };
 }
@@ -358,14 +357,13 @@ export default {
         this.reject(error);
       }
     },
-    setBanner({ icon, text, action, ariaLabel, triggerActionFrom, showBanner = false }) {
+    setBanner({ icon, text, action, ariaLabel, triggerActionFrom }) {
       this.bannerProps = {
         text,
         ariaLabel,
         icon: icon ? { source: icon.source, type: icon.type } : undefined,
         action: action ? { ...action } : undefined,
         triggerActionFrom: triggerActionFrom || "banner",
-        showBanner,
       };
     },
     setHeaderTitle(title, info) {

--- a/packages/frontend/src/youi/App.vue
+++ b/packages/frontend/src/youi/App.vue
@@ -36,7 +36,11 @@
         <v-row class="prompts-col">
           <v-col>
             <YOUIDone v-if="isDone" :done-status="doneStatus" :done-message="doneMessage" :done-path="donePath" />
-
+            <YOUIBanner
+              v-if="bannerProps.text && bannerProps.ariaLabel"
+              :bannerProps="bannerProps"
+              :vscode="getVsCodeApi()"
+            />
             <YOUIPromptInfo v-if="currentPrompt && !isDone" :current-prompt="currentPrompt" />
             <v-slide-x-transition>
               <Form
@@ -111,6 +115,7 @@ import YOUINavigation from "../components/YOUINavigation.vue";
 import YOUIDone from "../components/YOUIDone.vue";
 import YOUIInfo from "../components/YOUIInfo.vue";
 import YOUIPromptInfo from "../components/YOUIPromptInfo.vue";
+import YOUIBanner from "../components/YOUIBanner.vue";
 import { RpcBrowser } from "@sap-devx/webview-rpc/out.browser/rpc-browser";
 import { RpcBrowserWebSockets } from "@sap-devx/webview-rpc/out.browser/rpc-browser-ws";
 import _size from "lodash/size";
@@ -165,6 +170,14 @@ function initialState() {
     headerTitleProvided: "",
     headerInfo: "",
     currentAnswerTexts: {}, // Answer state for navigation answer history
+    bannerProps: {
+      icon: "",
+      iconColor: "",
+      text: "",
+      linkText: "",
+      linkCommand: "",
+      ariaLabel: "Notification Banner"
+    }
   };
 }
 
@@ -176,6 +189,7 @@ export default {
     YOUIDone,
     YOUIInfo,
     YOUIPromptInfo,
+    YOUIBanner,
     Loading,
   },
   props: {
@@ -342,6 +356,16 @@ export default {
         this.rpc.invoke("logError", [error]);
         this.reject(error);
       }
+    },
+    setBanner({ icon, iconColor, text, linkText, linkCommand, ariaLabel }) {
+      this.bannerProps = {
+        icon,
+        iconColor,
+        text,
+        linkText,
+        linkCommand,
+        ariaLabel
+      };
     },
     setHeaderTitle(title, info) {
       this.headerTitleProvided = title;
@@ -635,6 +659,7 @@ export default {
         "showPromptMessage",
         "resetPromptMessage",
         "setHeaderTitle",
+        "setBanner",
       ];
       _forEach(functions, (funcName) => {
         this.rpc.registerMethod({

--- a/packages/frontend/src/youi/App.vue
+++ b/packages/frontend/src/youi/App.vue
@@ -176,7 +176,6 @@ function initialState() {
       icon: {},
       action: {},
       triggerActionFrom: "banner",
-      linkText: "",
       showBanner: false
     },
   };
@@ -359,14 +358,13 @@ export default {
         this.reject(error);
       }
     },
-    setBanner({ icon, text, action, ariaLabel, triggerActionFrom, linkText, showBanner = false }) {
+    setBanner({ icon, text, action, ariaLabel, triggerActionFrom, showBanner = false }) {
       this.bannerProps = {
         text,
         ariaLabel,
         icon: icon ? { source: icon.source, type: icon.type } : undefined,
         action: action ? { ...action } : undefined,
         triggerActionFrom: triggerActionFrom || "banner",
-        linkText: linkText,
         showBanner
       };
     },

--- a/packages/frontend/src/youi/App.vue
+++ b/packages/frontend/src/youi/App.vue
@@ -175,9 +175,10 @@ function initialState() {
       ariaLabel: "Banner",
       icon: {},
       action: {},
-      triggerActionFrom: "banner", 
+      triggerActionFrom: "banner",
       linkText: "",
-    }
+      showBanner: false
+    },
   };
 }
 
@@ -363,8 +364,8 @@ export default {
         text,
         ariaLabel,
         icon: icon ? { source: icon.source, type: icon.type } : undefined,
-        action: action ? { ...action } : undefined, 
-        triggerActionFrom: triggerActionFrom || "banner", 
+        action: action ? { ...action } : undefined,
+        triggerActionFrom: triggerActionFrom || "banner",
         linkText: linkText,
         showBanner
       };

--- a/packages/frontend/src/youi/App.vue
+++ b/packages/frontend/src/youi/App.vue
@@ -38,7 +38,7 @@
             <YOUIDone v-if="isDone" :done-status="doneStatus" :done-message="doneMessage" :done-path="donePath" />
             <YOUIBanner
               v-if="bannerProps.showBanner && bannerProps.text && bannerProps.ariaLabel"
-              :bannerProps="bannerProps"
+              :banner-props="bannerProps"
               @parent-execute-command="executeCommand"
             />
             <YOUIPromptInfo v-if="currentPrompt && !isDone" :current-prompt="currentPrompt" />

--- a/packages/frontend/test/App.spec.js
+++ b/packages/frontend/test/App.spec.js
@@ -1215,10 +1215,10 @@ describe("App.vue", () => {
               text: "Test Banner",
               ariaLabel: "Test Banner Label",
               showBanner: true,
-              triggerActionFrom: "banner"
-            }
-          }
-        }
+              triggerActionFrom: "banner",
+            },
+          };
+        },
       });
 
       // Check if YOUIBanner is rendered
@@ -1230,7 +1230,7 @@ describe("App.vue", () => {
         text: "Test Banner",
         ariaLabel: "Test Banner Label",
         showBanner: true,
-        triggerActionFrom: "banner"
+        triggerActionFrom: "banner",
       });
 
       // Check if the banner text is rendered correctly
@@ -1247,10 +1247,10 @@ describe("App.vue", () => {
               text: "Test Banner",
               ariaLabel: "Test Banner Label",
               showBanner: false, // Banner should not be displayed
-              triggerActionFrom: "banner"
-            }
-          }
-        }
+              triggerActionFrom: "banner",
+            },
+          };
+        },
       });
 
       // Check if YOUIBanner is not rendered
@@ -1265,7 +1265,7 @@ describe("App.vue", () => {
         showBanner: true,
         icon: { source: "mdi-check-circle", type: "mdi" },
         action: { text: "Click Me", url: "https://example.com" },
-        triggerActionFrom: "banner"
+        triggerActionFrom: "banner",
       };
 
       wrapper = mount(App, {
@@ -1286,7 +1286,7 @@ describe("App.vue", () => {
         showBanner: true,
         icon: { source: "mdi-check-circle", type: "mdi" },
         action: { text: "Click Me", url: "https://example.com" },
-        triggerActionFrom: "banner"
+        triggerActionFrom: "banner",
       });
     });
   });

--- a/packages/frontend/test/App.spec.js
+++ b/packages/frontend/test/App.spec.js
@@ -2,6 +2,8 @@ import { initComponent, unmount } from "./Utils";
 import App from "../src/youi/App";
 import { WebSocket } from "mock-socket";
 import { nextTick } from "vue";
+import { mount } from "@vue/test-utils";
+import YOUIBanner from "../src/components/YOUIBanner.vue";
 
 global.WebSocket = WebSocket;
 
@@ -1193,6 +1195,101 @@ describe("App.vue", () => {
       expect(wrapper.vm.toShowPromptMessage).toEqual(false);
       expect(wrapper.vm.promptMessageIcon).toEqual(null);
       expect(wrapper.vm.promptMessageClass).toEqual("");
+    });
+  });
+
+  describe("YOUIBanner Component in App.vue", () => {
+    let wrapper;
+
+    afterEach(() => {
+      if (wrapper) {
+        wrapper.unmount();
+      }
+    });
+
+    test("renders YOUIBanner when bannerProps.showBanner is true", () => {
+      wrapper = mount(App, {
+        data() {
+          return {
+            bannerProps: {
+              text: "Test Banner",
+              ariaLabel: "Test Banner Label",
+              showBanner: true,
+              triggerActionFrom: "banner",
+            },
+          };
+        },
+      });
+
+      // Check if YOUIBanner is rendered
+      const banner = wrapper.findComponent(YOUIBanner);
+      expect(banner.exists()).toBe(true);
+
+      // Check if props are passed correctly
+      expect(banner.props("bannerProps")).toEqual({
+        text: "Test Banner",
+        ariaLabel: "Test Banner Label",
+        showBanner: true,
+        triggerActionFrom: "banner",
+      });
+
+      // Check if the banner text is rendered correctly
+      const bannerText = banner.find(".banner-text span");
+      expect(bannerText.exists()).toBe(true);
+      expect(bannerText.text()).toBe("Test Banner");
+    });
+
+    test("does not render YOUIBanner when bannerProps.showBanner is false", () => {
+      wrapper = mount(App, {
+        data() {
+          return {
+            bannerProps: {
+              text: "Test Banner",
+              ariaLabel: "Test Banner Label",
+              showBanner: false, // Banner should not be displayed
+              triggerActionFrom: "banner",
+            },
+          };
+        },
+      });
+
+      // Check if YOUIBanner is not rendered
+      const banner = wrapper.findComponent(YOUIBanner);
+      expect(banner.exists()).toBe(false);
+    });
+
+    test("setBanner method updates bannerProps correctly", () => {
+      const bannerProps = {
+        text: "Test Banner",
+        ariaLabel: "Test Banner Label",
+        showBanner: true,
+        icon: { source: "mdi-check-circle", type: "mdi" },
+        action: { text: "Click Me", url: "https://example.com" },
+        triggerActionFrom: "banner",
+        linkText: "Learn More",
+      };
+
+      wrapper = mount(App, {
+        data() {
+          return {
+            bannerProps,
+          };
+        },
+      });
+
+      // Call setBanner method
+      wrapper.vm.setBanner(bannerProps);
+
+      // Check if bannerProps are updated correctly
+      expect(wrapper.vm.bannerProps).toEqual({
+        text: "Test Banner",
+        ariaLabel: "Test Banner Label",
+        showBanner: true,
+        icon: { source: "mdi-check-circle", type: "mdi" },
+        action: { text: "Click Me", url: "https://example.com" },
+        triggerActionFrom: "banner",
+        linkText: "Learn More",
+      });
     });
   });
 });

--- a/packages/frontend/test/App.spec.js
+++ b/packages/frontend/test/App.spec.js
@@ -1207,14 +1207,13 @@ describe("App.vue", () => {
       }
     });
 
-    test("renders YOUIBanner when bannerProps.showBanner is true", () => {
+    test("renders YOUIBanner when bannerProps title and ariaLabel is true", () => {
       wrapper = mount(App, {
         data() {
           return {
             bannerProps: {
               text: "Test Banner",
               ariaLabel: "Test Banner Label",
-              showBanner: true,
               triggerActionFrom: "banner",
             },
           };
@@ -1229,7 +1228,6 @@ describe("App.vue", () => {
       expect(banner.props("bannerProps")).toEqual({
         text: "Test Banner",
         ariaLabel: "Test Banner Label",
-        showBanner: true,
         triggerActionFrom: "banner",
       });
 
@@ -1239,14 +1237,11 @@ describe("App.vue", () => {
       expect(bannerText.text()).toBe("Test Banner");
     });
 
-    test("does not render YOUIBanner when bannerProps.showBanner is false", () => {
+    test("does not render YOUIBanner when title and aria label is not provided", () => {
       wrapper = mount(App, {
         data() {
           return {
             bannerProps: {
-              text: "Test Banner",
-              ariaLabel: "Test Banner Label",
-              showBanner: false, // Banner should not be displayed
               triggerActionFrom: "banner",
             },
           };
@@ -1262,7 +1257,6 @@ describe("App.vue", () => {
       const bannerProps = {
         text: "Test Banner",
         ariaLabel: "Test Banner Label",
-        showBanner: true,
         icon: { source: "mdi-check-circle", type: "mdi" },
         action: { text: "Click Me", url: "https://example.com" },
         triggerActionFrom: "banner",
@@ -1283,7 +1277,6 @@ describe("App.vue", () => {
       expect(wrapper.vm.bannerProps).toEqual({
         text: "Test Banner",
         ariaLabel: "Test Banner Label",
-        showBanner: true,
         icon: { source: "mdi-check-circle", type: "mdi" },
         action: { text: "Click Me", url: "https://example.com" },
         triggerActionFrom: "banner",

--- a/packages/frontend/test/App.spec.js
+++ b/packages/frontend/test/App.spec.js
@@ -1253,34 +1253,124 @@ describe("App.vue", () => {
       expect(banner.exists()).toBe(false);
     });
 
-    test("setBanner method updates bannerProps correctly", () => {
+    test("renders YOUIBanner when currentPrompt name matches displayBannerForStep", () => {
       const bannerProps = {
         text: "Test Banner",
+        displayBannerForStep: "Test Step",
         ariaLabel: "Test Banner Label",
         icon: { source: "mdi-check-circle", type: "mdi" },
         action: { text: "Click Me", url: "https://example.com" },
         triggerActionFrom: "banner",
       };
 
+      const currentPrompt = {
+        name: "Test Step",
+        status: "pending",
+        questions: [],
+      };
+
       wrapper = mount(App, {
+        computed: {
+          shouldDisplayBanner() {
+            // Mock the computed property to return true
+            return (
+              bannerProps.displayBannerForStep &&
+              currentPrompt.name === bannerProps.displayBannerForStep &&
+              bannerProps.text &&
+              bannerProps.ariaLabel
+            );
+          },
+        },
         data() {
           return {
             bannerProps,
+            currentPrompt,
           };
         },
       });
 
-      // Call setBanner method
       wrapper.vm.setBanner(bannerProps);
+      expect(wrapper.vm.bannerProps).toEqual(bannerProps);
 
-      // Check if bannerProps are updated correctly
-      expect(wrapper.vm.bannerProps).toEqual({
+      // Check if YOUIBanner is rendered
+      const banner = wrapper.findComponent(YOUIBanner);
+      expect(banner.exists()).toBe(true);
+    });
+
+    test("does not render YOUIBanner when currentPrompt name does not match displayBannerForStep", () => {
+      const bannerProps = {
         text: "Test Banner",
+        displayBannerForStep: "Test Step",
         ariaLabel: "Test Banner Label",
         icon: { source: "mdi-check-circle", type: "mdi" },
         action: { text: "Click Me", url: "https://example.com" },
         triggerActionFrom: "banner",
+      };
+
+      const currentPrompt = {
+        name: "some other step",
+        status: "pending",
+        questions: [],
+      };
+
+      wrapper = mount(App, {
+        computed: {
+          shouldDisplayBanner() {
+            return (
+              bannerProps.displayBannerForStep &&
+              currentPrompt.name === bannerProps.displayBannerForStep &&
+              bannerProps.text &&
+              bannerProps.ariaLabel
+            );
+          },
+        },
+        data() {
+          return {
+            bannerProps,
+            currentPrompt,
+          };
+        },
       });
+
+      wrapper.vm.setBanner(bannerProps);
+      // Check if YOUIBanner is not rendered
+      const banner = wrapper.findComponent(YOUIBanner);
+      expect(banner.exists()).toBe(false);
+    });
+
+    test("renders YOUIBanner when bannerProps title and ariaLabel is true and no displayBannerForStep is provided", () => {
+      wrapper = mount(App, {
+        data() {
+          return {
+            bannerProps: {
+              text: "Test Banner",
+              ariaLabel: "Test Banner Label",
+              triggerActionFrom: "banner",
+            },
+            currentPrompt: {
+              key: "Test Step",
+              status: "pending",
+              questions: [],
+            },
+          };
+        },
+      });
+
+      // Check if YOUIBanner is rendered
+      const banner = wrapper.findComponent(YOUIBanner);
+      expect(banner.exists()).toBe(true);
+
+      // Check if props are passed correctly
+      expect(banner.props("bannerProps")).toEqual({
+        text: "Test Banner",
+        ariaLabel: "Test Banner Label",
+        triggerActionFrom: "banner",
+      });
+
+      // Check if the banner text is rendered correctly
+      const bannerText = banner.find(".banner-text span");
+      expect(bannerText.exists()).toBe(true);
+      expect(bannerText.text()).toBe("Test Banner");
     });
   });
 });

--- a/packages/frontend/test/App.spec.js
+++ b/packages/frontend/test/App.spec.js
@@ -1215,10 +1215,10 @@ describe("App.vue", () => {
               text: "Test Banner",
               ariaLabel: "Test Banner Label",
               showBanner: true,
-              triggerActionFrom: "banner",
-            },
-          };
-        },
+              triggerActionFrom: "banner"
+            }
+          }
+        }
       });
 
       // Check if YOUIBanner is rendered
@@ -1230,7 +1230,7 @@ describe("App.vue", () => {
         text: "Test Banner",
         ariaLabel: "Test Banner Label",
         showBanner: true,
-        triggerActionFrom: "banner",
+        triggerActionFrom: "banner"
       });
 
       // Check if the banner text is rendered correctly
@@ -1247,10 +1247,10 @@ describe("App.vue", () => {
               text: "Test Banner",
               ariaLabel: "Test Banner Label",
               showBanner: false, // Banner should not be displayed
-              triggerActionFrom: "banner",
-            },
-          };
-        },
+              triggerActionFrom: "banner"
+            }
+          }
+        }
       });
 
       // Check if YOUIBanner is not rendered
@@ -1265,8 +1265,7 @@ describe("App.vue", () => {
         showBanner: true,
         icon: { source: "mdi-check-circle", type: "mdi" },
         action: { text: "Click Me", url: "https://example.com" },
-        triggerActionFrom: "banner",
-        linkText: "Learn More",
+        triggerActionFrom: "banner"
       };
 
       wrapper = mount(App, {
@@ -1287,8 +1286,7 @@ describe("App.vue", () => {
         showBanner: true,
         icon: { source: "mdi-check-circle", type: "mdi" },
         action: { text: "Click Me", url: "https://example.com" },
-        triggerActionFrom: "banner",
-        linkText: "Learn More",
+        triggerActionFrom: "banner"
       });
     });
   });

--- a/packages/frontend/test/components/Banner.spec.js
+++ b/packages/frontend/test/components/Banner.spec.js
@@ -15,7 +15,6 @@ describe("YOUIBanner.vue", () => {
       bannerProps: {
         text: "Test Banner",
         ariaLabel: "Test Banner Label",
-        showBanner: true,
         triggerActionFrom: "banner",
       },
     };
@@ -37,7 +36,6 @@ describe("YOUIBanner.vue", () => {
       bannerProps: {
         text: "Test Banner",
         ariaLabel: "Test Banner Label",
-        showBanner: true,
         icon: {
           source: "mdi-check-circle",
           type: "mdi",
@@ -66,7 +64,6 @@ describe("YOUIBanner.vue", () => {
       bannerProps: {
         text: "Test Banner",
         ariaLabel: "Test Banner Label",
-        showBanner: true,
         icon: {
           source:
             "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mP8//8/AwAI/wH+9Q4AAAAASUVORK5CYII=",
@@ -96,7 +93,6 @@ describe("YOUIBanner.vue", () => {
       bannerProps: {
         text: "Test Banner",
         ariaLabel: "Test Banner Label",
-        showBanner: true,
         triggerActionFrom: "banner",
         action: {
           command: {
@@ -126,7 +122,6 @@ describe("YOUIBanner.vue", () => {
       bannerProps: {
         text: "Test Banner",
         ariaLabel: "Test Banner Label",
-        showBanner: true,
         triggerActionFrom: "link",
         action: {
           text: "Click Me",
@@ -150,7 +145,6 @@ describe("YOUIBanner.vue", () => {
       bannerProps: {
         text: "Test Banner",
         ariaLabel: "Test Banner Label",
-        showBanner: true,
         triggerActionFrom: "link",
         action: {
           text: "Click Me",

--- a/packages/frontend/test/components/Banner.spec.js
+++ b/packages/frontend/test/components/Banner.spec.js
@@ -134,7 +134,7 @@ describe("YOUIBanner.vue", () => {
       props: propsData,
     });
 
-    const link = wrapper.find(".banner-link a");
+    const link = wrapper.find(".banner-link-text a");
     expect(link.exists()).toBe(true);
     expect(link.text()).toBe("Click Me");
     expect(link.attributes("href")).toBe("https://example.com");
@@ -160,7 +160,7 @@ describe("YOUIBanner.vue", () => {
       props: propsData,
     });
 
-    const link = wrapper.find(".banner-link a");
+    const link = wrapper.find(".banner-link-text a");
     expect(link.exists()).toBe(true);
     expect(link.text()).toBe("Click Me");
 

--- a/packages/frontend/test/components/Banner.spec.js
+++ b/packages/frontend/test/components/Banner.spec.js
@@ -16,12 +16,12 @@ describe("YOUIBanner.vue", () => {
         text: "Test Banner",
         ariaLabel: "Test Banner Label",
         showBanner: true,
-        triggerActionFrom: "banner"
-      }
+        triggerActionFrom: "banner",
+      },
     };
 
     wrapper = mount(Banner, {
-      props: propsData
+      props: propsData,
     });
 
     const props = wrapper.props();
@@ -40,9 +40,9 @@ describe("YOUIBanner.vue", () => {
         showBanner: true,
         icon: {
           source: "mdi-check-circle",
-          type: "mdi"
-        }
-      }
+          type: "mdi",
+        },
+      },
     };
 
     wrapper = mount(Banner, {
@@ -70,9 +70,9 @@ describe("YOUIBanner.vue", () => {
         icon: {
           source:
             "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mP8//8/AwAI/wH+9Q4AAAAASUVORK5CYII=",
-          type: "image"
-        }
-      }
+          type: "image",
+        },
+      },
     };
 
     wrapper = mount(Banner, {
@@ -101,10 +101,10 @@ describe("YOUIBanner.vue", () => {
         action: {
           command: {
             id: "test.command",
-            params: { key: "value" }
-          }
-        }
-      }
+            params: { key: "value" },
+          },
+        },
+      },
     };
 
     wrapper = mount(Banner, {
@@ -130,9 +130,9 @@ describe("YOUIBanner.vue", () => {
         triggerActionFrom: "link",
         action: {
           text: "Click Me",
-          url: "https://example.com"
-        }
-      }
+          url: "https://example.com",
+        },
+      },
     };
 
     wrapper = mount(Banner, {
@@ -156,10 +156,10 @@ describe("YOUIBanner.vue", () => {
           text: "Click Me",
           command: {
             id: "test.command",
-            params: { key: "value" }
-          }
-        }
-      }
+            params: { key: "value" },
+          },
+        },
+      },
     };
 
     wrapper = mount(Banner, {

--- a/packages/frontend/test/components/Banner.spec.js
+++ b/packages/frontend/test/components/Banner.spec.js
@@ -1,0 +1,180 @@
+import { mount } from "@vue/test-utils";
+import { nextTick } from "vue";
+import Banner from "../../src/components/YOUIBanner.vue";
+import { unmount } from "../Utils";
+
+describe("YOUIBanner.vue", () => {
+  let wrapper;
+
+  afterEach(() => {
+    unmount(wrapper);
+  });
+
+  test("renders minimal banner with correct text", () => {
+    const propsData = {
+      bannerProps: {
+        text: "Test Banner",
+        ariaLabel: "Test Banner Label",
+        showBanner: true,
+        triggerActionFrom: "banner",
+      },
+    };
+
+    wrapper = mount(Banner, {
+      props: propsData,
+    });
+
+    const props = wrapper.props();
+    expect(props).toEqual(propsData);
+
+    const bannerText = wrapper.find(".banner-text span");
+    expect(bannerText.exists()).toBe(true);
+    expect(bannerText.text()).toBe("Test Banner");
+  });
+
+  test("renders material icon correctly in banner", async () => {
+    const propsData = {
+      bannerProps: {
+        text: "Test Banner",
+        ariaLabel: "Test Banner Label",
+        showBanner: true,
+        icon: {
+          source: "mdi-check-circle",
+          type: "mdi",
+        },
+      },
+    };
+
+    wrapper = mount(Banner, {
+      props: propsData,
+    });
+
+    const props = wrapper.props();
+    expect(props).toEqual(propsData);
+
+    const bannerText = wrapper.find(".banner-text span");
+    expect(bannerText.exists()).toBe(true);
+    expect(bannerText.text()).toBe("Test Banner");
+
+    const bannerIcon = wrapper.find(".banner-icon v-icon");
+    expect(bannerIcon.exists()).toBe(true);
+    expect(bannerIcon.text()).toBe("mdi-check-circle");
+  });
+
+  test("renders image icon correctly in banner", async () => {
+    const propsData = {
+      bannerProps: {
+        text: "Test Banner",
+        ariaLabel: "Test Banner Label",
+        showBanner: true,
+        icon: {
+          source:
+            "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mP8//8/AwAI/wH+9Q4AAAAASUVORK5CYII=",
+          type: "image",
+        },
+      },
+    };
+
+    wrapper = mount(Banner, {
+      props: propsData,
+    });
+
+    const props = wrapper.props();
+    expect(props).toEqual(propsData);
+
+    const bannerText = wrapper.find(".banner-text span");
+    expect(bannerText.exists()).toBe(true);
+    expect(bannerText.text()).toBe("Test Banner");
+
+    const bannerIcon = wrapper.find(".banner-icon img");
+    expect(bannerIcon.exists()).toBe(true);
+    expect(bannerIcon.attributes("src")).toBe(propsData.bannerProps.icon.source);
+  });
+
+  test('emits parent-execute-command event when triggerActionFrom is "banner"', async () => {
+    const propsData = {
+      bannerProps: {
+        text: "Test Banner",
+        ariaLabel: "Test Banner Label",
+        showBanner: true,
+        triggerActionFrom: "banner",
+        action: {
+          command: {
+            id: "test.command",
+            params: { key: "value" },
+          },
+        },
+      },
+    };
+
+    wrapper = mount(Banner, {
+      props: propsData,
+    });
+
+    const props = wrapper.props();
+    expect(props).toEqual(propsData);
+
+    wrapper.vm.triggerCommand(wrapper.vm.bannerProps.action.command);
+    await nextTick();
+
+    expect(wrapper.emitted()["parent-execute-command"]).toBeTruthy();
+    expect(wrapper.emitted()["parent-execute-command"][0]).toEqual([{ id: "test.command", params: { key: "value" } }]);
+  });
+
+  test('renders clickable link correctly when triggerActionFrom is "link"', async () => {
+    const propsData = {
+      bannerProps: {
+        text: "Test Banner",
+        ariaLabel: "Test Banner Label",
+        showBanner: true,
+        triggerActionFrom: "link",
+        action: {
+          text: "Click Me",
+          url: "https://example.com",
+        },
+      },
+    };
+
+    wrapper = mount(Banner, {
+      props: propsData,
+    });
+
+    const link = wrapper.find(".banner-link a");
+    expect(link.exists()).toBe(true);
+    expect(link.text()).toBe("Click Me");
+    expect(link.attributes("href")).toBe("https://example.com");
+  });
+
+  test('renders clickable command correctly when triggerActionFrom is "link"', async () => {
+    const propsData = {
+      bannerProps: {
+        text: "Test Banner",
+        ariaLabel: "Test Banner Label",
+        showBanner: true,
+        triggerActionFrom: "link",
+        action: {
+          text: "Click Me",
+          command: {
+            id: "test.command",
+            params: { key: "value" },
+          },
+        },
+      },
+    };
+
+    wrapper = mount(Banner, {
+      props: propsData,
+    });
+
+    const link = wrapper.find(".banner-link a");
+    expect(link.exists()).toBe(true);
+    expect(link.text()).toBe("Click Me");
+
+    wrapper.vm.triggerCommand(wrapper.vm.bannerProps.action.command);
+    await nextTick();
+
+    expect(wrapper.emitted()["parent-execute-command"]).toBeTruthy();
+    expect(wrapper.emitted()["parent-execute-command"][0]).toEqual([{ id: "test.command", params: { key: "value" } }]);
+    expect(link.attributes("href")).toBe("javascript:void(0)");
+  });
+});

--- a/packages/frontend/test/components/Banner.spec.js
+++ b/packages/frontend/test/components/Banner.spec.js
@@ -88,7 +88,7 @@ describe("YOUIBanner.vue", () => {
     expect(bannerIcon.attributes("src")).toBe(propsData.bannerProps.icon.source);
   });
 
-  test('emits parent-execute-command event when triggerActionFrom is "banner"', async () => {
+  test('emits parent-execute-command event when action is triggered from banner', async () => {
     const propsData = {
       bannerProps: {
         text: "Test Banner",

--- a/packages/frontend/test/components/Banner.spec.js
+++ b/packages/frontend/test/components/Banner.spec.js
@@ -16,12 +16,12 @@ describe("YOUIBanner.vue", () => {
         text: "Test Banner",
         ariaLabel: "Test Banner Label",
         showBanner: true,
-        triggerActionFrom: "banner",
-      },
+        triggerActionFrom: "banner"
+      }
     };
 
     wrapper = mount(Banner, {
-      props: propsData,
+      props: propsData
     });
 
     const props = wrapper.props();
@@ -40,9 +40,9 @@ describe("YOUIBanner.vue", () => {
         showBanner: true,
         icon: {
           source: "mdi-check-circle",
-          type: "mdi",
-        },
-      },
+          type: "mdi"
+        }
+      }
     };
 
     wrapper = mount(Banner, {
@@ -70,9 +70,9 @@ describe("YOUIBanner.vue", () => {
         icon: {
           source:
             "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mP8//8/AwAI/wH+9Q4AAAAASUVORK5CYII=",
-          type: "image",
-        },
-      },
+          type: "image"
+        }
+      }
     };
 
     wrapper = mount(Banner, {
@@ -101,10 +101,10 @@ describe("YOUIBanner.vue", () => {
         action: {
           command: {
             id: "test.command",
-            params: { key: "value" },
-          },
-        },
-      },
+            params: { key: "value" }
+          }
+        }
+      }
     };
 
     wrapper = mount(Banner, {
@@ -130,9 +130,9 @@ describe("YOUIBanner.vue", () => {
         triggerActionFrom: "link",
         action: {
           text: "Click Me",
-          url: "https://example.com",
-        },
-      },
+          url: "https://example.com"
+        }
+      }
     };
 
     wrapper = mount(Banner, {
@@ -156,10 +156,10 @@ describe("YOUIBanner.vue", () => {
           text: "Click Me",
           command: {
             id: "test.command",
-            params: { key: "value" },
-          },
-        },
-      },
+            params: { key: "value" }
+          }
+        }
+      }
     };
 
     wrapper = mount(Banner, {

--- a/packages/frontend/test/components/Banner.spec.js
+++ b/packages/frontend/test/components/Banner.spec.js
@@ -88,7 +88,7 @@ describe("YOUIBanner.vue", () => {
     expect(bannerIcon.attributes("src")).toBe(propsData.bannerProps.icon.source);
   });
 
-  test('emits parent-execute-command event when action is triggered from banner', async () => {
+  test("emits parent-execute-command event when action is triggered from banner", async () => {
     const propsData = {
       bannerProps: {
         text: "Test Banner",

--- a/packages/frontend/test/components/Navigation.spec.js
+++ b/packages/frontend/test/components/Navigation.spec.js
@@ -1,6 +1,6 @@
 import { initComponent, unmount } from "../Utils";
 import Navigation from "../../src/components/YOUINavigation.vue";
-import { nextTick, toHandlerKey } from "vue";
+import { nextTick } from "vue";
 //There are issues of importing vuetify components https://github.com/vuejs/vue-cli/issues/1584
 // import { VBtn } from 'vuetify/lib'
 

--- a/packages/frontend/test/components/Navigation.spec.js
+++ b/packages/frontend/test/components/Navigation.spec.js
@@ -1,6 +1,6 @@
 import { initComponent, unmount } from "../Utils";
 import Navigation from "../../src/components/YOUINavigation.vue";
-import { nextTick } from "vue";
+import { nextTick, toHandlerKey } from "vue";
 //There are issues of importing vuetify components https://github.com/vuejs/vue-cli/issues/1584
 // import { VBtn } from 'vuetify/lib'
 

--- a/packages/generator-foodq/CHANGELOG.md
+++ b/packages/generator-foodq/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.19.5](https://github.com/SAP/yeoman-ui/compare/v1.19.4...v1.19.5) (2025-06-10)
+
+**Note:** Version bump only for package generator-foodq
+
 ## [1.19.4](https://github.com/SAP/yeoman-ui/compare/v1.19.3...v1.19.4) (2025-06-10)
 
 **Note:** Version bump only for package generator-foodq

--- a/packages/generator-foodq/package.json
+++ b/packages/generator-foodq/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-foodq",
-  "version": "1.19.4",
+  "version": "1.19.5",
   "private": true,
   "description": "A sample generator to preview all the options available when using the Yeoman-UI",
   "keywords": [
@@ -18,7 +18,7 @@
     "yeoman.png"
   ],
   "dependencies": {
-    "@sap-devx/yeoman-ui-types": "^1.19.4",
+    "@sap-devx/yeoman-ui-types": "^1.19.5",
     "chalk-pipe": "^4.0.0",
     "datauri": "^3.0.0",
     "inquirer": "^7.3.3",

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.19.5](https://github.com/SAP/yeoman-ui/compare/v1.19.4...v1.19.5) (2025-06-10)
+
+**Note:** Version bump only for package @sap-devx/yeoman-ui-types
+
 ## [1.19.4](https://github.com/SAP/yeoman-ui/compare/v1.19.3...v1.19.4) (2025-06-10)
 
 **Note:** Version bump only for package @sap-devx/yeoman-ui-types

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sap-devx/yeoman-ui-types",
   "displayName": "yeoman-ui-types",
-  "version": "1.19.4",
+  "version": "1.19.5",
   "description": "Yeoman-UI prompt types",
   "repository": {
     "type": "git",

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -64,24 +64,53 @@ export interface IPrompt {
   description: string;
 }
 
-export interface IAction {
+/**
+ * Action where 'text' is present and links to a VS Code command.
+ */
+interface IActionWithTextAndCommand {
+  /**
+   * The display text for the action.
+   * Clicking this text triggers the associated VS Code command.
+   */
+  text: string;
+
   /**
    * Command to be executed and parameters passed to the command
    */
-  command?: {
+  command: {
     id: string;
     params?: Object | string;
   };
+
   /**
-   * The text associated with the command
-   * Clicking this text triggers the command or opens a url in new tab
+   * A URL string.
+   * This should not be present when 'command' is defined.
    */
-  text?: string;
-  /**
-   * A http URL string
-   */
-  url?: string;
+  url?: never;
 }
+
+/**
+ * Action where 'text' is present and links to a URL.
+ */
+interface IActionWithTextAndUrl {
+  /**
+   * The display text for the action.
+   * Clicking this text triggers the associated VS Code command.
+   */
+  text: string;
+
+  /**
+   * Command to be executed and parameters passed to the command
+   */
+  command?: never;
+
+  /**
+   * A URL string.
+   */
+  url: string;
+}
+
+export type IAction = IActionWithTextAndUrl | IActionWithTextAndCommand;
 
 export interface IBannerProps {
   /**

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -122,9 +122,10 @@ export interface IBannerProps {
    */
   ariaLabel: string;
   /**
-   * Determines whether the banner should be displayed
+   * Determines the step during which the banner should be displayed.
+   * If not provided, the banner will not be tied to a specific step and may appear globally.
    */
-  showBanner?: boolean;
+  displayBannerForStep?: string;
   /**
    * Icon metadata, including the icon source and type
    */

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -4,6 +4,14 @@ export abstract class AppWizard {
   abstract showError(message: string, type: MessageType): void;
   abstract showInformation(message: string, type: MessageType): void;
   abstract setHeaderTitle(title: string, additionalInfo?: string): void;
+  abstract setBanner(bannerProps: {
+    text: string;
+    ariaLabel: string;
+    icon?: string;
+    iconColor?: string;
+    linkText?: string;
+    linkCommand?: string;
+  }): void;
 
   public static create(genOptions: any = {}): AppWizard {
     class EmptyAppWizard extends AppWizard {
@@ -12,6 +20,7 @@ export abstract class AppWizard {
       showError(): void {}
       showInformation(): void {}
       setHeaderTitle(): void {}
+      setBanner(): void {}
     }
 
     return genOptions.appWizard ? genOptions.appWizard : new EmptyAppWizard();

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -4,14 +4,7 @@ export abstract class AppWizard {
   abstract showError(message: string, type: MessageType): void;
   abstract showInformation(message: string, type: MessageType): void;
   abstract setHeaderTitle(title: string, additionalInfo?: string): void;
-  abstract setBanner(bannerProps: {
-    text: string;
-    ariaLabel: string;
-    icon?: string;
-    iconColor?: string;
-    linkText?: string;
-    linkCommand?: string;
-  }): void;
+  abstract setBanner(bannerProps: IBannerProps): void;
 
   public static create(genOptions: any = {}): AppWizard {
     class EmptyAppWizard extends AppWizard {
@@ -69,6 +62,63 @@ export class Prompts {
 export interface IPrompt {
   name: string;
   description: string;
+}
+
+export interface IAction {
+  /**
+   * Command to be executed and parameters passed to the command
+   */
+  command?: {
+    id: string;
+    params?: Object | string;
+  };
+  /**
+   * The text associated with the command
+   * Clicking this text triggers the command or opens a url in new tab
+   */
+  text?: string;
+  /**
+   * A http URL string
+   */
+  url?: string;
+}
+
+export interface IBannerProps {
+  /**
+   * The main text to display in the banner
+   */
+  text: string;
+  /**
+   * Accessibility label for the banner
+   */
+  ariaLabel: string;
+  /**
+   * Determines whether the banner should be displayed
+   */
+  showBanner?: boolean;
+  /**
+   * Icon metadata, including the icon source and type
+   */
+  icon?: {
+    /**
+     * The actual icon data (e.g., Base64 string for images or icon name for Material Design icons)
+     */
+    source: string;
+    /**
+     * Specifies the type of the icon (e.g., "image" for Base64 images or "mdi" for Material Design icons)
+     */
+    type: "image" | "mdi";
+  };
+  /**
+   * Action to be triggered (common for both banner click and link click)
+   */
+  action: IAction;
+  /**
+   * Determines where the action should be triggered
+   * - `banner`: Action is triggered on banner click
+   * - `link`: Action is triggered on link click
+   */
+  triggerActionFrom: "banner" | "link";
 }
 
 /**


### PR DESCRIPTION
- Add new support for Banner in `YOUIBanner.vue`
- Introduced new Banner Props `IBannerProps` to `@sap-devx/yeoman-ui-types`

  - `text` (string): Main text displayed in the banner.
  - `ariaLabel` (string): Accessibility label for screen readers.
  - `displayBannerForStep`: The step during which the banner should be displayed.
  - `icon` (object, optional): Metadata for the banner icon:
  - `source` (string): Icon data (e.g., Base64 string or Material Design icon name).
  - `type` ("image" | "mdi"): Icon type (image for Base64 or mdi for Material Design).
  - `triggerActionFrom` ("banner" | "link"): Specifies where the action is triggered. If Banner action is triggered on clicking the whole banner, if link then action is triggered on text or link click.
  - `action` (IAction): Defines the action triggered by the banner or link:
  - `command` (object, optional): command to be triggered
  - `params` (object| string): Optional parameteres to trigger action
  - `id`(string): Command Id to be triggered
  - `text` Text for the action.
  - `url` (string, optional): HTTP URL to open.

Note action can include command or url as action to trigger on click of text.
Example of a banner with trigger command from a link

```ts
const bannerProps: IBannerProps = {
  text: "Welcome to the app!",
  ariaLabel: "Banner for accessibility",
  icon: {
    source: "mdi-check-circle",
    type: "mdi",
  },
  action: {
    text: "Learn More",
    url: "https://example.com",
  },
  triggerActionFrom: "link",
};
```

Example of a banner with trigger command from a banner

```ts
const bannerProps: IBannerProps = {
  text: "Welcome to the app!",
  ariaLabel: "Banner for accessibility",
  icon: {
    source: "mdi-check-circle",
    type: "mdi",
  },
  action: {
    command: {
          id: 'some.command.string'
    },
    text: "Click Banner"
  },
  triggerActionFrom: "banner",
};
```

- Added setBanner support to the backend
- Added tests