### PR TITLE
chore(banner): fix commit message linting to make build pass

### DIFF
--- a/packages/frontend/src/components/YOUIBanner.vue
+++ b/packages/frontend/src/components/YOUIBanner.vue
@@ -79,7 +79,7 @@ const { bannerProps } = toRefs(props);
 
 /**
  * Trigger the command action and emit the event to the parent component
- * @param {Object} event - The event object
+ * @param {Object} event - Event object
  */
 const triggerCommand = (event) => {
   emit("parent-execute-command", event);


### PR DESCRIPTION
The build on master is [failing](https://github.com/SAP/yeoman-ui/commit/5c963aebc1392fda79c08d05ebfa29223ca5c281)  for [PR](https://github.com/SAP/yeoman-ui/pull/899).
Added a new commit message to comply with linting rules and make build pass on master.