### PR TITLE
chore: consume inquirer-gui v3.4.6

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -60,7 +60,7 @@
   },
   "dependencies": {
     "@mdi/font": "5.9.55",
-    "@sap-devx/inquirer-gui": "3.4.5",
+    "@sap-devx/inquirer-gui": "3.4.6",
     "@sap-devx/inquirer-gui-auto-complete-plugin": "3.0.6",
     "@sap-devx/inquirer-gui-file-browser-plugin": "3.0.3",
     "@sap-devx/inquirer-gui-folder-browser-plugin": "3.0.3",


### PR DESCRIPTION
Consume the latest Inquirer GUI v3.4.6
