### PR TITLE
feat(37088): add OutputTabLinkResult and ShowOutputTabLink to yeoman-…

### DIFF
--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -197,3 +197,25 @@ export interface IMessageSeverity {
   message: string;
   severity: Severity;
 }
+
+/**
+ * Describes the result of a dynamic `showOutputTabLink` function.
+ * - `show` — whether the link should be displayed.
+ * - `linkMessage` — optional custom label for the link (e.g. "View logs in odata downloader").
+ *   Falls back to the default label when omitted.
+ */
+export type OutputTabLinkResult = { show: boolean; linkMessage?: string };
+
+/**
+ * Controls visibility of the link below a question that opens the output channel.
+ * - `'validationMessageOverflow'` — link appears only when a validation error text overflows 2 lines (clamped).
+ * - A function `() => OutputTabLinkResult | boolean | Promise<OutputTabLinkResult | boolean>` —
+ *   called at runtime (via RPC) to dynamically determine whether the link should be shown and
+ *   what label it should carry. The consumer controls both visibility and the link message.
+ *
+ * The consumer application (e.g. App Wizard) is responsible for wiring the link click
+ * to the appropriate output-channel command.
+ */
+export type ShowOutputTabLink =
+  | 'validationMessageOverflow'
+  | (() => OutputTabLinkResult | boolean | Promise<OutputTabLinkResult | boolean>);

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -217,5 +217,5 @@ export type OutputTabLinkResult = { show: boolean; linkMessage?: string };
  * to the appropriate output-channel command.
  */
 export type ShowOutputTabLink =
-  | 'validationMessageOverflow'
+  | "validationMessageOverflow"
   | (() => OutputTabLinkResult | boolean | Promise<OutputTabLinkResult | boolean>);


### PR DESCRIPTION
…ui-types

These types belong in @sap-devx/yeoman-ui-types so consumers of yeoman-ui can import them without depending on @sap-ux/inquirer-common (open-ux-tools).

The types describe the showOutputTabLink question property API that controls visibility of the output channel link below a question in the App Wizard.

Related to internal issue **Output tab command link for long error messages in the Generator** #37088