### PR TITLE
fix: hide empty generator info links

### DIFF
--- a/packages/frontend/src/exploregens/App.vue
+++ b/packages/frontend/src/exploregens/App.vue
@@ -70,8 +70,8 @@
               {{ gen.package.description }}
             </v-card-text>
             <v-spacer />
-            <v-card-text class="homepage">
-              <a class="text-blue" :href="gen.package.links.npm">{{ messages.more_info }}</a>
+            <v-card-text v-if="generatorInfoUrl(gen)" class="homepage">
+              <a class="text-blue" :href="generatorInfoUrl(gen)">{{ messages.more_info }}</a>
             </v-card-text>
             <v-card-actions class="pa-4">
               <v-btn
@@ -184,6 +184,9 @@ export default {
       }
 
       return gen.state === "installed" ? "#585858" : "";
+    },
+    generatorInfoUrl(gen) {
+      return _get(gen, "package.links.npm", "");
     },
     onAction(gen) {
       const action = gen.action.toLowerCase();

--- a/packages/frontend/test/Exploregens.spec.js
+++ b/packages/frontend/test/Exploregens.spec.js
@@ -1,0 +1,74 @@
+import { mount } from "@vue/test-utils";
+import { createVuetify } from "vuetify";
+import * as components from "vuetify/lib/components/index.mjs";
+import * as directives from "vuetify/lib/directives/index.mjs";
+import ExploreGenerators from "../src/exploregens/App.vue";
+
+class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+global.ResizeObserver = ResizeObserver;
+
+describe("Explore generators", () => {
+  const mountExploreGenerators = (gens) => {
+    const vuetify = createVuetify({
+      components,
+      directives,
+    });
+    const component = {
+      ...ExploreGenerators,
+      created() {},
+    };
+
+    return mount(component, {
+      global: {
+        plugins: [vuetify],
+      },
+      data() {
+        return {
+          ready: true,
+          isLegalNoteAccepted: true,
+          gens,
+          total: gens.length,
+        };
+      },
+      attachTo: document.body,
+    });
+  };
+
+  test("hides more information link when generator has no link", () => {
+    const wrapper = mountExploreGenerators([
+      {
+        package: {
+          name: "generator-no-link",
+          version: "1.0.0",
+          description: "No link",
+          links: {},
+        },
+      },
+    ]);
+
+    expect(wrapper.find(".homepage a").exists()).toBe(false);
+  });
+
+  test("shows more information link when generator has a link", () => {
+    const wrapper = mountExploreGenerators([
+      {
+        package: {
+          name: "generator-with-link",
+          version: "1.0.0",
+          description: "Has link",
+          links: {
+            npm: "https://www.npmjs.com/package/generator-with-link",
+          },
+        },
+      },
+    ]);
+
+    const link = wrapper.find(".homepage a");
+    expect(link.exists()).toBe(true);
+    expect(link.attributes("href")).toBe("https://www.npmjs.com/package/generator-with-link");
+  });
+});


### PR DESCRIPTION
## Summary
- hide the generator info link when no URL is available
- add a frontend regression test for both link states

Fixes #681

## Checks
- yarn test --runTestsByPath test/Exploregens.spec.js --coverage=false
- eslint packages/frontend/src/exploregens/App.vue packages/frontend/test/Exploregens.spec.js
- prettier --check packages/frontend/src/exploregens/App.vue packages/frontend/test/Exploregens.spec.js
- yarn workspace @sap-devx/yeoman-ui-types compile && yarn build
- git diff --check
